### PR TITLE
feat!: refactor spifit and mosaic onto the pfb-imaging datatree, add spimple init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,17 @@ install with auto-generated [Stimela](https://github.com/caracal-pipeline/stimel
 definitions and containerised execution. The project prioritises **simplicity and
 minimalism** over feature completeness.
 
-Four commands, each a thin `cli/` wrapper over a `core/` implementation:
+Five commands, each a thin `cli/` wrapper over a `core/` implementation. `init`, `mosaic`
+and `spifit` operate on an `xarray.DataTree` store laid out exactly as `pfb imager` writes
+it, so a pfb tree is consumed directly — see `docs/wiki/datatree-contract.md`.
 
 | Command | What it does |
 |---|---|
-| `spimple spifit` | Fits a spectral index model to an image cube, optionally convolving and applying a primary beam on the fly. |
-| `spimple imconv` | Convolves images to a common resolution, optionally with primary beam correction. |
-| `spimple binterp` | Interpolates a primary beam model onto an image's coordinate grid. |
-| `spimple mosaic` | Reprojects and combines images onto a common coordinate grid. |
+| `spimple init` | Ingests FITS into a datatree: partitions by phase centre, bands by frequency, resolution homogenised, beams attached, partitions reprojected onto a union grid. |
+| `spimple mosaic` | Combines a datatree's image-space partitions into band mean images. Never needed for a pfb tree, which mosaics in visibility space. |
+| `spimple spifit` | Fits a spectral index model to the band images of a datatree. |
+| `spimple binterp` | Interpolates a primary beam model onto an image's coordinate grid. FITS in, FITS out; the only home of the MS-derived DDE beam path. |
+| `spimple imconv` | **Deprecated**, subsumed by `init`. Removal in a follow-up PR. |
 
 *Detailed architecture, Python standards and CI rules are modularised into
 `.claude/rules/` for progressive disclosure. Read the relevant file before editing the
@@ -25,6 +28,7 @@ matching files.*
 | Rule file | Read it when editing |
 |---|---|
 | `.claude/rules/architecture.md` | `src/spimple/**` — layout, install modes, container fallback, cab generation. |
+| `docs/wiki/datatree-contract.md` | anything reading or writing a `.dt` store — the layout, its invariants, and what spimple ignores in a pfb tree. |
 | `.claude/rules/python-standards.md` | any `**/*.py` — type hints, lazy imports, Typer syntax, hip-cargo types. |
 | `.claude/rules/testing-and-ci.md` | `tests/**` or `.github/workflows/**` — round-trip tests, fixtures, commits. |
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ consumed directly. FITS input from any other imager is ingested into the same la
 
 ```bash
 # images from pfb-imaging: no ingest step at all
-pfb restore --output-filename out --gausspar 8.0 6.4 0.0
-spimple spifit --store out_I.dt --output-filename spi
+pfb restore --output-filename out --gausspar 0.00222 0.00178 0.0  # degrees: 8.0 x 6.4 arcsec
+spimple spifit --store out_I.dt --flux-scale mixed --output-filename spi
 
 # FITS from any other imager
 spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
@@ -28,6 +28,10 @@ spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
 spimple mosaic --store out_I.dt            # only if the input had several pointings
 spimple spifit --store out_I.dt --output-filename spi
 ```
+
+`pfb restore` defaults to `--outputs kK`, which writes `KIMAGE` only — hence
+`--flux-scale mixed` above. Ask it for `--outputs kKaA` if you want to fit the apparent
+scale, which is `spifit`'s own default.
 
 `pfb imager` mosaics in visibility space, so its band nodes arrive already populated —
 **`spimple mosaic` is never part of a pfb workflow.**
@@ -70,12 +74,13 @@ spimple init \
     --residual "field*-residual.fits" \
     --output-filename out/field \
     --beam-model JimBeam \
-    --psf-pars 8.0 6.4 0.0
+    --psf-pars 0.00222 0.00178 0.0
 ```
 
 Writes `out/field_I.dt`, the product suffix coming from the input STOKES axis. Files
 sharing a phase centre and grid become one partition; each distinct frequency becomes a
-band. `--psf-pars` is `emaj emin pa` in degrees; omit it to take the lowest resolution of
+band. `--psf-pars` is `emaj emin pa` in **degrees** (the example above is 8.0 x 6.4
+arcsec); omit it to take the lowest resolution of
 the inputs. `--beam-model` accepts `JimBeam`, a FITS beam cube, or a meerkat-beams
 `.bds.zarr` store.
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ spimple spifit --store out_I.dt --flux-scale mixed --output-filename spi
 spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
              --output-filename out --beam-model JimBeam
 spimple mosaic --store out_I.dt            # only if the input had several pointings
-spimple spifit --store out_I.dt --output-filename spi
+spimple spifit --store out_I.dt --flux-scale apparent --output-filename spi
 ```
 
-`pfb restore` defaults to `--outputs kK`, which writes `KIMAGE` only — hence
-`--flux-scale mixed` above. Ask it for `--outputs kKaA` if you want to fit the apparent
-scale, which is `spifit`'s own default.
+`--flux-scale` is required and has no default: the three scales mean different things,
+and which products a tree even holds depends on how it was made. `pfb restore` defaults to
+`--outputs kK`, which writes `KIMAGE` only — hence `--flux-scale mixed` above. Ask it for
+`--outputs kKaA` if you want the apparent scale too.
 
 `pfb imager` mosaics in visibility space, so its band nodes arrive already populated —
 **`spimple mosaic` is never part of a pfb workflow.**
@@ -107,10 +108,12 @@ spimple spifit \
 `I` reconstructed cube, `d` data minus fitted model, `b` average power beam. Files are
 named `<output-filename>_time{t}.<product>.fits`. Unfitted pixels are `NaN`, not zero.
 
-`--flux-scale` picks which stored product to fit: `apparent` (`BIMAGE`, the default,
-fitted together with the beam), `intrinsic` (`IMAGE`, already beam-corrected) or `mixed`
-(`KIMAGE`). The tree must already be at one resolution — `spimple init` or
-`pfb restore --gausspar` does that.
+`--flux-scale` is **required** and picks which stored product to fit: `apparent`
+(`BIMAGE`, fitted together with the beam), `intrinsic` (`IMAGE`, already beam-corrected)
+or `mixed` (`KIMAGE`). All three pass the band's mean `BEAM` map to the fitter as the
+first-order response; `mixed` is an intrinsic model plus an apparent residual, so its beam
+handling is approximate by construction. The tree must already be at one resolution —
+`spimple init` or `pfb restore --gausspar` does that.
 
 ### Interpolate a primary beam
 
@@ -134,6 +137,7 @@ comma-separated string and accept glob patterns.
 - `spifit` and `mosaic` take `--store`, a datatree, instead of FITS images. Their
   FITS-specific options are gone; convolution, beams, frequencies and weights now come
   from the tree.
+- `spifit --flux-scale` is required, with no default.
 - `imconv` is deprecated and warns on use. It will be removed in a following release.
 - `Gaussian2D` was producing kernels 8.51 % too wide, so every convolution now homogenises
   to the resolution actually requested. Output changes accordingly.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,35 @@
 
 Radio astronomy image post-processing, made simple.
 
-`spimple` provides four commands for working with FITS image cubes produced by radio
-interferometric imagers:
+`spimple` works with the same `xarray.DataTree` store that
+[pfb-imaging](https://github.com/ratt-ru/pfb-imaging) writes, so a tree produced by pfb is
+consumed directly. FITS input from any other imager is ingested into the same layout by
+`spimple init`.
 
 | Command | What it does |
 |---|---|
-| `spimple spifit` | Fits a spectral index model to an image cube, optionally convolving to a common resolution and applying a primary beam correction on the fly. |
-| `spimple imconv` | Convolves images to a common resolution, optionally with primary beam correction. |
-| `spimple binterp` | Interpolates a primary beam model onto an image's coordinate grid. |
-| `spimple mosaic` | Reprojects and combines multiple images onto a common coordinate grid. |
+| `spimple init` | Ingests FITS images into a datatree, grouping them into partitions by phase centre and into bands by frequency, and homogenising resolution. |
+| `spimple mosaic` | Combines a datatree's image-space partitions into band mean images. Only needed for multi-pointing input from `init`. |
+| `spimple spifit` | Fits a spectral index model to the band images of a datatree. |
+| `spimple binterp` | Interpolates a primary beam model onto an image's coordinate grid. FITS in, FITS out. |
+| `spimple imconv` | **Deprecated.** Convolves images to a common resolution. Use `spimple init`. |
+
+### The two workflows
+
+```bash
+# images from pfb-imaging: no ingest step at all
+pfb restore --output-filename out --gausspar 8.0 6.4 0.0
+spimple spifit --store out_I.dt --output-filename spi
+
+# FITS from any other imager
+spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
+             --output-filename out --beam-model JimBeam
+spimple mosaic --store out_I.dt            # only if the input had several pointings
+spimple spifit --store out_I.dt --output-filename spi
+```
+
+`pfb imager` mosaics in visibility space, so its band nodes arrive already populated —
+**`spimple mosaic` is never part of a pfb workflow.**
 
 It follows the [hip-cargo](https://github.com/landmanbester/hip-cargo) package format, so
 every command is available both on the command line and as a
@@ -42,33 +62,50 @@ spimple --help
 spimple spifit --help
 ```
 
+### Build a datatree from FITS
+
+```bash
+spimple init \
+    --images "field*-model.fits" \
+    --residual "field*-residual.fits" \
+    --output-filename out/field \
+    --beam-model JimBeam \
+    --psf-pars 8.0 6.4 0.0
+```
+
+Writes `out/field_I.dt`, the product suffix coming from the input STOKES axis. Files
+sharing a phase centre and grid become one partition; each distinct frequency becomes a
+band. `--psf-pars` is `emaj emin pa` in degrees; omit it to take the lowest resolution of
+the inputs. `--beam-model` accepts `JimBeam`, a FITS beam cube, or a meerkat-beams
+`.bds.zarr` store.
+
+### Combine a multi-pointing datatree
+
+```bash
+spimple mosaic --store out/field_I.dt --fits-outputs iI
+```
+
+Solves `(sum_p B_p^2 + eta) S = sum_p B_p A_p` per band to populate the band mean images.
+Skip this for single-pointing input: `init` writes the band products itself.
+
 ### Fit a spectral index map
 
 ```bash
 spimple spifit \
-    --images "image-cube.fits" \
-    --residual "residual-cube.fits" \
+    --store out/field_I.dt \
     --output-filename out/field \
+    --flux-scale apparent \
     --products aeikI
 ```
 
-`--products` is a string of letters selecting outputs: `a` alpha map, `e` alpha error,
-`i` I0 map, `k` I0 error, `I` reconstructed cube, `c` restoring beam, `m` convolved model,
-`r` convolved residual, `b` average power beam, `d` data minus fitted model.
+`--products` selects outputs: `a` alpha map, `e` alpha error, `i` I0 map, `k` I0 error,
+`I` reconstructed cube, `d` data minus fitted model, `b` average power beam. Files are
+named `<output-filename>_time{t}.<product>.fits`. Unfitted pixels are `NaN`, not zero.
 
-### Convolve to a common resolution
-
-```bash
-spimple imconv \
-    --images "image-*.fits" \
-    --output-filename out/convolved \
-    --psf-pars 8.0 6.4 0.0 \
-    --products ic
-```
-
-`--psf-pars` is `emaj emin pa` in degrees. Omit it to take the resolution from the FITS
-header. Note the data are Jy/beam, so convolving to a coarser beam scales pixel values by
-the ratio of beam areas.
+`--flux-scale` picks which stored product to fit: `apparent` (`BIMAGE`, the default,
+fitted together with the beam), `intrinsic` (`IMAGE`, already beam-corrected) or `mixed`
+(`KIMAGE`). The tree must already be at one resolution — `spimple init` or
+`pfb restore --gausspar` does that.
 
 ### Interpolate a primary beam
 
@@ -81,26 +118,29 @@ spimple binterp \
 
 `--beam-model` is a path *prefix*; the loader expects `<prefix>_xx_re.fits` and its
 `_im.fits`, `_yy_*` pair alongside. See
-[`docs/wiki/fits-and-beams.md`](docs/wiki/fits-and-beams.md) for the full convention.
+[`docs/wiki/fits-and-beams.md`](docs/wiki/fits-and-beams.md) for the full convention. The
+output cube can be fed straight to `spimple init --beam-model`.
 
-### Mosaic
+List-valued options (`--images`, `--residual`, `--ms`, `--deselect-bands`) take a
+comma-separated string and accept glob patterns.
 
-```bash
-spimple mosaic \
-    --images "field*-image.fits" \
-    --output-filename out/mosaic.fits \
-    --beam-model /path/to/beam.bds.zarr
-```
+## Breaking changes in this release
 
-List-valued options (`--images`, `--residual`, `--ms`, `--channel-freqs`,
-`--deselect-bands`) take a comma-separated string and accept glob patterns.
+- `spifit` and `mosaic` take `--store`, a datatree, instead of FITS images. Their
+  FITS-specific options are gone; convolution, beams, frequencies and weights now come
+  from the tree.
+- `imconv` is deprecated and warns on use. It will be removed in a following release.
+- `Gaussian2D` was producing kernels 8.51 % too wide, so every convolution now homogenises
+  to the resolution actually requested. Output changes accordingly.
+- `set_wcs` wrote a `CRVAL3` one channel too high for any multi-channel cube, and raised
+  `IndexError` for a two-channel one. Both fixed.
 
 ## Running in a container
 
 Every command takes `--backend`:
 
 ```bash
-spimple imconv --backend docker --images "image.fits" --output-filename out/conv
+spimple init --backend docker --images "image.fits" --output-filename out/field
 ```
 
 `auto` (the default) tries to run natively and falls back to a detected container runtime.
@@ -115,8 +155,8 @@ Cab definitions ship inside the package, so a recipe can include them directly:
 
 ```yaml
 _include:
+  - (spimple.cabs)init.yml
   - (spimple.cabs)spifit.yml
-  - (spimple.cabs)imconv.yml
 ```
 
 The cabs are generated from the CLI source and pinned to a versioned container image, so

--- a/docs/wiki/datatree-contract.md
+++ b/docs/wiki/datatree-contract.md
@@ -1,0 +1,113 @@
+---
+type: reference
+title: The DataTree contract with pfb-imaging
+description: The store layout spimple reads and writes, its invariants, and how a spimple tree differs from a pfb-imaging one.
+tags: [datatree, zarr, pfb-imaging, interop, conventions]
+timestamp: 2026-08-13
+last_verified_commit: b7bfbc4
+---
+
+# The DataTree contract with pfb-imaging
+
+`spimple spifit` and `spimple mosaic` operate on an `xarray.DataTree` store, not on loose
+FITS files. The layout is the one `pfb imager` writes, so a tree produced by pfb-imaging is
+consumed by spimple **directly**, with no ingest step.
+
+`src/spimple/utils/datatree.py` is the single owner of this layout. Everything else goes
+through it, so the contract has exactly one place to drift from. Pinned by
+`tests/test_datatree.py` and by the synthetic `pfb_tree` fixture in `tests/conftest.py`.
+
+## The two workflows
+
+```
+pfb origin     pfb imager -> pfb deconv -> pfb restore --gausspar ...
+                                                  |
+                                                  v  <out>_I.dt
+                                            spimple spifit
+
+FITS origin    spimple init --images ... -o out        -> out_I.dt
+               spimple mosaic --store out_I.dt         (only if >1 partition)
+               spimple spifit --store out_I.dt
+```
+
+**`spimple mosaic` is never part of a pfb workflow.** `pfb imager` mosaics in *visibility*
+space — its partitions are summed into the band node during gridding — so a pfb tree
+arrives with its band nodes already populated. `mosaic` exists solely to combine the
+*image-space* partitions that `spimple init` creates from multi-pointing FITS input. It
+refuses a tree whose partitions carry no `MASK`/`BIMAGE`, which is exactly the pfb case.
+
+## Layout
+
+```
+out_I.dt/                                    # xr.open_datatree(..., engine="zarr")
+  (root attrs)
+      product, nband, ntime, nx, ny, cell_rad
+      origin = "spimple-init"                # absent on a pfb tree
+
+  band{b:04d}_time{t:04d}/                   # one output image
+      attrs:
+          bandid, timeid, freq_out, freq_nominal, time_out,
+          ra, dec, cell_rad, l0, m0, pb_min
+      vars:
+          IMAGE      (corr, y, x)   intrinsic, at PSFPARSF
+          BIMAGE     (corr, y, x)   apparent,  at PSFPARSF
+          KIMAGE     (corr, y, x)   intrinsic model + apparent residual
+          BEAM       (corr, y, x)
+          WSUM       (corr,)
+          RMS        (corr,)        spimple only; absent on a pfb tree
+          PSFPARSF   (corr, bpar)   the common target resolution
+          SPATIALWGT (corr, y, x)   written by mosaic only
+
+      part{p:04d}/                           # one input pointing
+          attrs:
+              field_name, ra0, dec0, freq_out, psfparsn,
+              beam_includes_n
+          vars:
+              IMAGE, BIMAGE, KIMAGE, BEAM, MASK  (corr, y, x)
+              WSUM, RMS (corr,), PSFPARSF (corr, bpar)
+```
+
+`bpar` is the coordinate `["BMAJ", "BMIN", "BPA"]`; `corr` carries the Stokes labels.
+
+`init` writes the band-node **image** variables only when the band has exactly one
+partition. With several partitions the band node carries its attrs and `PSFPARSF` alone
+until `mosaic` runs — combining is mosaic's job, and init must not guess a band-level
+image.
+
+## Invariants
+
+Each of these is asserted in `utils/datatree.py` or pinned by a test. They are where a
+spimple tree could silently diverge from a pfb one.
+
+| Invariant | Statement |
+|---|---|
+| **Axis order** | Every image variable is `(corr, y, x)`. No transposes on the tree path; `save_fits` is called with `yx_order=True`. The only test that catches a violation is the orientation test in `tests/test_render.py` — everything else passes while transposed. |
+| **Resolution units** | `PSFPARSN`/`PSFPARSF` are `(emaj, emin, pa)` in **pixels, pixels, radians**, matching pfb. FITS `BMAJ`/`BMIN` (degrees) are divided by `cell_deg`; `BPA` goes through `deg2rad`. `set_wcs` converts back with `unit2deg=cell_x`. |
+| **Flux scale** | `IMAGE` intrinsic, `BIMAGE` apparent, `KIMAGE` mixed — pfb's three scales, same names (`PRODUCT_VARS`). All are Jy/beam at `PSFPARSF`, already normalised. |
+| **No native-resolution copy** | spimple never persists a native `MODEL`/`RESIDUAL`: the input FITS is the archive. pfb's "divide the stored `RESIDUAL` by `WSUM`" step therefore has no spimple analogue. |
+| **Beam semantics** | On a spimple tree `BEAM` is the bare primary beam and `beam_includes_n` is False. On a pfb tree `BEAM` is `B/n` with the flag True — see design-decisions.md. |
+| **Grid** | Every partition under a band node is on the union grid. Native-grid arrays are never stored: `reproject_interp` conserves surface brightness, not flux, so a Jy/pixel model would not survive it. Convolving first makes everything Jy/beam, after which reprojection is sound. |
+| **Time** | `time_out` is **unix seconds**, so headers are rendered with `set_wcs(time_is_unix=True)`. |
+| **Band ordering** | Consumers sort band nodes by `bandid`, never by `freq_out`. Effective frequencies are data-dependent and asymmetric flagging can invert two bands. |
+| **Attribute merging** | `to_zarr(mode="a")` replaces a group's attrs wholesale, so `write_node` starts from the group's existing attrs and merges. |
+
+## What spimple reads, and what it ignores
+
+A pfb tree carries much more than spimple needs. spimple reads the band-node products
+above and nothing else; it must never *require* the rest:
+
+- ignored: `DIRTY`, `BDIRTY`, `PSF`, `PSFHAT`, `PSFPARSN`, `MODEL`, `BRESIDUAL`, `NOISE`,
+  and every visibility-space array under `part####` (`VIS`, `WEIGHT`, `UVW`, `FREQ`,
+  `MASK` in its vis-space sense);
+- read opportunistically: `RESIDUAL`, used only to estimate a threshold rms when the tree
+  carries no `RMS` variable. Its absence is never an error.
+
+## Sources
+
+- pfb-imaging `docs/wiki/imager-pipeline.md` (tree layout) and
+  `docs/wiki/image-and-beam-orientation.md` §6 (the reprojection construction), branch
+  `dev-0.1.0` at commit `b84407b`.
+- `src/spimple/utils/datatree.py`, `src/spimple/utils/render.py`,
+  `src/spimple/core/init.py`, `src/spimple/core/mosaic.py`, `src/spimple/core/spifit.py`.
+- `tests/test_datatree.py`, `tests/test_render.py`, and the `pfb_tree` fixture in
+  `tests/conftest.py`.

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -139,6 +139,20 @@ degrees. `spifit` logs a warning naming the correction (`B = BEAM * n`, evaluate
 tree's own grid from `cell_rad`, `l0`, `m0`) rather than silently absorbing it. Deferred to
 a follow-up PR by decision, not oversight.
 
+### Two cab-contract issues in the DataTree commands
+
+Both are declaration problems, not defects in the science path, and are deferred to a
+follow-up PR.
+
+1. **`init`'s cab advertises `implicit="{current.output-filename}_I.dt"`**, but `core.init`
+   derives the store suffix from the FITS STOKES axis, so a `Q` or `XXYY` input produces
+   `..._Q.dt` while the cab tells Stimela to expect `..._I.dt`. Correct for the Stokes I
+   case, which is everything spimple is normally pointed at. Fixing it needs either an
+   explicit `--product` option or a declared output that carries no suffix.
+2. **`--beam-model` is declared `File` but accepts the literal `JimBeam`**, so Stimela may
+   try to validate or stage the sentinel as a path. `imconv` has always done the same, so
+   changing it either diverges from that convention for one command or changes both.
+
 ### The `.bds.zarr` beam backend is unverified against a real file
 
 `utils/beamsource._bds_beam` assumes the `l_beam`/`m_beam`/`chan`/`BEAM` names the

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -4,7 +4,7 @@ title: Design decisions and known defects
 description: The decision ledger for the hip-cargo port, plus the defects diagnosed but not fixed.
 tags: [architecture, decisions, known-issues]
 timestamp: 2026-08-13
-last_verified_commit: f3c2726
+last_verified_commit: b7bfbc4
 ---
 
 # Design decisions and known defects
@@ -40,6 +40,56 @@ an org package inherits its repository's access.)
 | D8 | `set_wcs` uses `astropy.time.Time`, not `casacore.quanta`. | Removes the only direct `python-casacore` import (it still arrives transitively via `codex-africanus[complete]`). Pinned by four regression vectors in `tests/test_fits.py` captured from the casacore implementation; they agree to better than 2.4e-7 s, far below the whole-second truncation applied. |
 | D9 | `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` is defaulted in `src/spimple/__init__.py`. | Ray ≥ 2.43 auto-injects a `runtime_env` when it detects `uv run` and hands itself the project directory as a URI. `ray.init` then dies with "… is not a valid URI", taking `spimple mosaic` out entirely. |
 | D10 | Two targeted `noqa`s are load-bearing: `N816` on `iFs`, `E402` on the four deferred imports in `cli/__init__.py`. | Preferred over widening the project-wide ignore list. Both rules only became live when the ruff config was replaced, which is why they were added in that commit and not earlier — under the old config they would have been unused suppressions tripping `RUF100`. |
+| D11 | No pfb-imaging dependency; the tree layout is a documented cross-repo contract instead. | `pfb_imaging.utils.misc` imports jax, numba, numexpr, daskms and skimage at module scope, so importing `convolve2gaussres` from it would drag in `pfb-imaging[full]`. spimple ports the handful of helpers it needs and owns the schema in `utils/datatree.py`. |
+| D12 | Partitions are derived from the data's own identity — phase centre plus grid — not from user labels. | A recipe should not have to spell out a grouping that the headers already state. Rounded to a thousandth of a pixel so header round-tripping cannot split a partition. |
+| D13 | `init` homogenises resolution; `mosaic` combines. `spifit` and `mosaic` both assume an already-homogenised tree. | Convolution lives in one place. For a pfb-origin tree the equivalent upstream step is `pfb restore --gausspar`, and `spifit` refuses with a message naming it. |
+| D14 | `init` writes the restore-named products `IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF`, and never persists a native-resolution `MODEL`/`RESIDUAL`. | Identical variable names to `pfb restore` means `spifit` needs no origin-specific branching. The input FITS is already the archive of the native-resolution data, so copying it into the store buys nothing. |
+| D15 | The band beam after mosaicking is `sum B^2 / sum B`, the beam-weighted mean — deliberately not pfb's WSUM-weighted mean. | It is the reduction consistent with the `B^2`-weighted solve that produced `IMAGE`, so `BEAM * IMAGE` is exactly the beam-weighted mean apparent image. pfb's D28 warns specifically against reducing a quantity and its weighting by different rules at the same level. Reduces to `B` where partitions agree and to `B_p` where only `p` covers. |
+| D16 | The mosaic normal equations are solved directly, not by conjugate gradient. | `(sum_p mask_p B_p^2 + eta) S = sum_p B_p A_p` is diagonal — purely elementwise — so the exact solution is one division and CG only iterates towards it. `conjugate_gradient` is retained for a future non-diagonal formulation and pinned against the direct solve by a test. `--cg-max-iter`/`--cg-tol` were dropped; `--eta` stays. |
+
+
+## Bugs found and fixed during the DataTree refactor
+
+- **`Gaussian2D` produced kernels 8.51 % too wide.** The exponent was
+  `exp(-fwhm_conv * R)` where the FWHM parametrisation requires `exp(-4 ln2 * R)`, i.e. a
+  coefficient of `0.5 * fwhm_conv**2`. Requesting a 10-pixel FWHM yielded 10.851. Verified
+  against pfb's `gaussian2d`, which matches to 1.7e-16 once the width is corrected, so the
+  position-angle parametrisations — which differ in form — are algebraically identical.
+  Every `imconv`/`spifit` convolution before this had homogenised to a resolution 8.51 %
+  coarser than requested. Pinned by `tests/test_convolution.py`.
+- **`set_wcs` read the reference frequency one channel too high.** It indexed the frequency
+  array with the *one-based* `CRPIX3`, so `CRVAL3` named the wrong channel, and a
+  two-channel cube raised `IndexError` — two bands being `spifit`'s documented minimum. It
+  survived because the only caller passing an array of frequencies was on the end-to-end
+  mosaic path the tests skipped. Pinned by `tests/test_fits.py`.
+- **`convolve2gaussres` tested `gausspari in [None, ()]`.** That is an elementwise
+  comparison for a numpy array and raises "truth value of an array is ambiguous". Every
+  legacy caller passed tuples of tuples, so it only surfaced once `restore_products` began
+  passing arrays.
+- **`ref_wcs.array_shape` was unpacked in both orders** — `(nyo, nxo)` in `core/mosaic.py`
+  and `(nxo, nyo)` in `utils/mosaic.py`, invisible only for square outputs. Both call sites
+  are gone with the rewrite.
+
+## A regression introduced and reverted, worth remembering
+
+Fixing the `Gaussian2D` width, its **support** was also changed from `nsigma * FWHM` to
+`nsigma * sigma`, to match both its docstring and pfb's `gaussian2d`. That broke the
+*deconvolution* path badly enough to displace sources.
+
+`convolve2gaussres` divides by the kernel's transform when `gausspari` is given. A
+Gaussian's transform decays to about 1e-14 by Nyquist; truncating the kernel at 5 sigma
+leaves a step of `exp(-12.5) = 3.7e-6` of peak whose spectral ripple is many orders of
+magnitude larger than that floor. The division amplifies it into ringing that moves the
+peak to *twice* its offset from the image centre. At 5 FWHM (11.8 sigma) the step is about
+4e-31 and the division is clean.
+
+Caught only by running `spimple init` end to end — a source at `x=20` rendered at `x=24` —
+because no unit test covered `gausspari != gaussparf`. That gap is now pinned by
+`test_convolve2gaussres_preserves_position_when_deconvolving`. **The same latent issue
+exists in pfb-imaging**, whose `gaussian2d` uses `nsigma * sigma_maj` while
+`restore_products` performs the identical division: reported as
+[ratt-ru/pfb-imaging#312](https://github.com/ratt-ru/pfb-imaging/issues/312), with the
+displacement measured at every image size from 32 to 1024 pixels.
 
 ## Bugs found and fixed during the port
 
@@ -78,6 +128,24 @@ All pre-existing; none introduced by the port.
   the bug survived. Found by Copilot's review of #49.
 
 ## Known defects, diagnosed but not fixed
+
+### `BEAM` from pfb-imaging is `B/n`, not the primary beam
+
+pfb's D22 folds the wgridder's geometric Jacobian into the stored beam, so a pfb tree's
+`BEAM` is the effective image-plane response `B/n` with `n = sqrt(1 - l^2 - m^2)`.
+Partitions carry `beam_includes_n: True` to say so. `spimple spifit` therefore applies
+`B/n` where it means `B`: about 0.2 % at a 5-degree field-of-view edge, 1.5 % at 10
+degrees. `spifit` logs a warning naming the correction (`B = BEAM * n`, evaluated on the
+tree's own grid from `cell_rad`, `l0`, `m0`) rather than silently absorbing it. Deferred to
+a follow-up PR by decision, not oversight.
+
+### The `.bds.zarr` beam backend is unverified against a real file
+
+`utils/beamsource._bds_beam` assumes the `l_beam`/`m_beam`/`chan`/`BEAM` names the
+pre-refactor `utils/mosaic.project` used, with a fallback to the `X`/`Y` spelling pfb's
+orientation wiki documents — both spellings have been in use. No real meerkat-beams dataset
+was available, and the test fixture only pins the reader against our own writer. Run it
+against a real `.bds.zarr` before advertising the backend.
 
 These are out of the port's scope. The diagnosis is recorded so nobody has to redo it.
 

--- a/docs/wiki/fits-and-beams.md
+++ b/docs/wiki/fits-and-beams.md
@@ -4,7 +4,7 @@ title: FITS and beam conventions
 description: The header conventions spimple's I/O assumes, and the beam-model layouts it expects.
 tags: [fits, wcs, beams, conventions]
 timestamp: 2026-08-13
-last_verified_commit: 49ecf34
+last_verified_commit: b7bfbc4
 ---
 
 # FITS and beam conventions
@@ -120,3 +120,28 @@ counts per time, so the beam is averaged over the observation rather than evalua
 single instant. `--sparsify-time` subsamples the time axis to keep that affordable, and
 `--field` picks the field whose phase centre is used. Antenna positions are checked for
 consistency across multiple measurement sets.
+
+
+## The DataTree path uses different I/O
+
+Everything above describes the FITS-to-FITS commands (`imconv`, `binterp`). The DataTree
+path — `init`, `mosaic`, `spifit` — differs deliberately:
+
+- **Arrays are (Y, X).** `load_fits` keeps its legacy `(1, 0, 3, 2)` transpose into (X, Y)
+  for the FITS-to-FITS commands. The tree path instead uses **`load_cube`**, which returns
+  `(nband, ncorr, ny, nx)` with the FITS raster untouched, and **`save_fits(yx_order=True)`**
+  to write it back.
+- **`load_cube` resolves the frequency-axis fork in one place.** It detects `CTYPE3` versus
+  `CTYPE4` itself and moves frequency to axis 0. Previously `imconv`, `spifit` and
+  `mosaic_info` each re-implemented that detection, and inconsistently — the trap this page
+  and `CLAUDE.md` both warned about. Pinned by asserting `load_cube` returns identical
+  arrays for the `image_cube` and `image_cube_ctype3` fixtures.
+- **Beams come from `utils/beamsource.py`,** which supports `JimBeam`, a FITS cube and a
+  meerkat-beams `.bds.zarr`, each evaluated on the partition's own grid around its own
+  phase centre and then reprojected. The FITS backend goes through `reproject_interp`, so
+  the pixel-exact coordinate match `imconv`/`spifit` demand is no longer required — a
+  `binterp` output cube is a valid `init --beam-model`.
+- **The MS-derived DDE path (`utils/beam.py`) is now reachable only from `binterp`.** It is
+  deliberately not an `init` backend, and its documented defects are unchanged.
+
+See [datatree-contract.md](datatree-contract.md) for the store layout itself.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -3,7 +3,7 @@ type: index
 title: spimple LLM wiki
 description: Progressive-disclosure listing of the in-repo knowledge bundle.
 timestamp: 2026-08-13
-last_verified_commit: 49ecf34
+last_verified_commit: b7bfbc4
 ---
 
 # spimple LLM wiki
@@ -31,6 +31,7 @@ update the page and refresh its stamp in the same session.
 | Page | Covers | Read when |
 |---|---|---|
 | [design-decisions.md](design-decisions.md) | The decision ledger, known defects, and the outstanding GitHub App setup | Before "fixing" something that looks wrong, or changing structure |
+| [datatree-contract.md](datatree-contract.md) | The DataTree store layout shared with pfb-imaging, its invariants, and which pfb variables spimple reads | Before touching `utils/datatree.py`, `core/init.py`, `core/mosaic.py`, `core/spifit.py`, or anything that writes to a store |
 | [fits-and-beams.md](fits-and-beams.md) | Frequency-axis conventions, per-channel beam keywords, beam-model layouts, JimBeam bands | Touching `utils/fits.py`, `utils/beam.py`, or any FITS fixture |
 
 ## Not covered here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ full = [
     "reproject",
     "scipy",
     "xarray",
+    "zarr",
 ]
 
 [project.scripts]

--- a/src/spimple/cabs/imconv.yml
+++ b/src/spimple/cabs/imconv.yml
@@ -4,7 +4,8 @@ cabs:
     command: spimple.core.imconv.imconv
     name: imconv
     info:
-      Homogenise resolution with Gaussian convolution
+      Convolve images to a common resolution.
+      Deprecated in favour of spimple init.
     policies:
       pass_missing_as_none: true
     image: ghcr.io/landmanbester/spimple:latest

--- a/src/spimple/cabs/init.yml
+++ b/src/spimple/cabs/init.yml
@@ -1,0 +1,117 @@
+cabs:
+  init:
+    flavour: python
+    command: spimple.core.init.init
+    name: init
+    info:
+      Ingest FITS images into a pfb-imaging style datatree
+    policies:
+      pass_missing_as_none: true
+    image: ghcr.io/landmanbester/spimple:latest
+    inputs:
+      images:
+        info:
+          List of FITS model or restored image files to ingest
+        dtype: List[str]
+        required: true
+        policies:
+          positional: true
+      output-filename:
+        info:
+          Basename of the output datatree store
+        dtype: File
+        required: true
+        policies:
+          positional: true
+      residual:
+        info:
+          List of FITS residual files matching the images
+        dtype: Optional[List[str]]
+      psf-pars:
+        info:
+          Target resolution as emaj emin pa in degrees.
+          By default the lowest resolution of the inputs is used
+        dtype: Optional[Tuple[float, float, float]]
+      circ-psf:
+        info:
+          Force a circular target beam
+        dtype: bool
+        default: false
+      dilate:
+        info:
+          Safety factor applied when the target resolution is derived from the inputs
+        dtype: float
+        default: 1.05
+      beam-model:
+        info:
+          Primary beam to apply.
+          Use JimBeam, a bds zarr store or a FITS cube
+        dtype: Optional[File]
+      band:
+        info:
+          Band to use with JimBeam.
+          L, UHF or S
+        choices:
+        - L
+        - UHF
+        - S
+        default: L
+      pb-min:
+        info:
+          Beam floor below which the intrinsic image is zeroed
+        dtype: float
+        default: 0.15
+      padding-frac:
+        info:
+          Padding used for the FFT based convolution
+        dtype: float
+        default: 0.5
+      products:
+        info:
+          Restored products to store.
+          a is apparent.
+          i is intrinsic.
+          k is mixed
+        default: aik
+      channel-weights-keyword:
+        info:
+          Header keyword supplying the per band weight sum
+        default: WSCVWSUM
+      freq-tol:
+        info:
+          Frequencies within this many Hz are treated as one band
+        dtype: Optional[float]
+      fits-outputs:
+        info:
+          Products to render as FITS.
+          Lowercase is MFS and uppercase is a cube
+        default: ''
+      fits-output-folder:
+        info:
+          Folder the rendered FITS are written to
+        dtype: Optional[Directory]
+      overwrite:
+        info:
+          Replace an existing datatree store
+        dtype: bool
+        default: false
+      out-dtype:
+        info:
+          Data type of output.
+          Default is single precision
+        default: f4
+      nthreads:
+        info:
+          Number of threads to use per worker
+        dtype: Optional[int]
+      nworkers:
+        info:
+          Number of workers to use for parallel processing
+        dtype: int
+        default: 1
+    outputs:
+      datatree:
+        dtype: Directory
+        info:
+          Datatree store consumed by spifit and mosaic.
+        implicit: '{current.output-filename}_I.dt'

--- a/src/spimple/cabs/mosaic.yml
+++ b/src/spimple/cabs/mosaic.yml
@@ -4,87 +4,60 @@ cabs:
     command: spimple.core.mosaic.mosaic
     name: mosaic
     info:
-      Reproject and combine multiple images into a mosaic.
+      Combine the partitions of a datatree into band mean images.
     policies:
       pass_missing_as_none: true
     image: ghcr.io/landmanbester/spimple:latest
     inputs:
-      images:
+      store:
         info:
-          List of FITS images to mosaic together
-        dtype: List[str]
+          Datatree store written by spimple init
+        dtype: Directory
         required: true
         policies:
           positional: true
       output-filename:
         info:
-          Path of the output mosaic FITS file
-        dtype: File
-        required: true
-        policies:
-          positional: true
-      beam-model:
-        info:
-          Beam dataset to apply.
-          Use binterp to make a power beam matching the images.
+          Basename for the rendered FITS files
         dtype: Optional[File]
-      band:
+      eta:
         info:
-          Band to use with JimBeam.
-          L, UHF or S
-        default: L
-      ref-image:
-        info:
-          Reference image defining the output coordinate system.
-          An optimal reference is derived when this is not provided.
-        dtype: Optional[File]
-      padding:
-        info:
-          Padding factor for FFTs.
+          Tikhonov floor keeping the solve finite where no partition covers
         dtype: float
-        default: 0.1
-      method:
+        default: 0.001
+      products:
         info:
-          Reprojection method, see reproject for details.
-        choices:
-        - interp
-        - adaptive
-        - exact
-        default: interp
-      nthreads:
+          Products to combine.
+          a is apparent.
+          i is intrinsic.
+          k is mixed
+        default: aik
+      fits-outputs:
         info:
-          Number of threads to use per worker.
-        dtype: int
-        default: 1
-      nworkers:
+          Products to render as FITS.
+          Lowercase is MFS and uppercase is a cube
+        default: I
+      fits-output-folder:
         info:
-          Number of workers to use for parallel processing.
-        dtype: int
-        default: 1
+          Folder the rendered FITS are written to
+        dtype: Optional[Directory]
       out-dtype:
         info:
           Data type of output.
           Default is single precision
         default: f4
-      convolve:
+      nthreads:
         info:
-          Flag to convolve images to common resolution before projection.
-          If no psf-pars are passed in the lowest resolution will be determined automatically.
-        dtype: bool
-        default: false
-      redo-project:
+          Number of threads to use per worker
+        dtype: Optional[int]
+      nworkers:
         info:
-          Force re-projection even if output exists.
-        dtype: bool
-        default: false
-      debug:
-        info:
-          Run everything in local mode to assist with debugging.
-        dtype: bool
-        default: false
+          Number of workers to use for parallel processing
+        dtype: int
+        default: 1
     outputs:
-      mosaic-image:
-        dtype: File
+      datatree:
+        dtype: Directory
         info:
-          Mosaicked image on the common coordinate grid.
-        implicit: '{current.output-filename}'
+          Datatree store with the band mean images populated.
+        implicit: '{current.store}'

--- a/src/spimple/cabs/spifit.yml
+++ b/src/spimple/cabs/spifit.yml
@@ -34,7 +34,9 @@ cabs:
         - apparent
         - intrinsic
         - mixed
-        default: apparent
+        required: true
+        policies:
+          positional: true
       products:
         info:
           Products to write, as a string of letters.

--- a/src/spimple/cabs/spifit.yml
+++ b/src/spimple/cabs/spifit.yml
@@ -4,140 +4,89 @@ cabs:
     command: spimple.core.spifit.spifit
     name: spifit
     info:
-      Fit spectral index map.
+      Fit a spectral index model to the band images of a datatree.
     policies:
       pass_missing_as_none: true
     image: ghcr.io/landmanbester/spimple:latest
     inputs:
-      images:
+      store:
         info:
-          Images to process
-        dtype: List[str]
+          Datatree store to fit.
+          Written by spimple init or by pfb-imaging
+        dtype: Directory
         required: true
         policies:
           positional: true
       output-filename:
         info:
-          Basename of output products
+          Basename of the output FITS products
         dtype: File
         required: true
         policies:
           positional: true
-      residual:
+      flux-scale:
         info:
-          Residual images matching the input images
-        dtype: Optional[List[str]]
-      psf-pars:
-        info:
-          PSF (beam) parameters matching FWHM of restoring beam specified as emaj emin pa.
-          Taken from the fits header by default.
-        dtype: Optional[Tuple[float, float, float]]
-      circ-psf:
-        info:
-          Flag to use circular restoring PSF (beam)
-        dtype: bool
-        default: false
-      threshold:
-        info:
-          Multiple of the rms in the residual to threshold on.
-          Only components above threshold*rms will be fit.
-        dtype: float
-        default: 10
-      max-dr:
-        info:
-          Maximum dynamic range used to determine the threshold.
-          Only used when residual is not available.
-        dtype: float
-        default: 1000
-      nthreads:
-        info:
-          Number of threads to use.
-          Defaults to all
-        dtype: Optional[int]
-      pb-min:
-        info:
-          Don't fit components where the primary beam is less than this
-        dtype: float
-        default: 0.15
+          Flux scale to fit.
+          Apparent uses BIMAGE.
+          Intrinsic uses IMAGE.
+          Mixed uses KIMAGE
+        choices:
+        - apparent
+        - intrinsic
+        - mixed
+        default: apparent
       products:
         info:
-          Outputs to write, as a string of letters.
+          Products to write, as a string of letters.
           a is the alpha map.
           e is the alpha error map.
           i is the I0 map.
           k is the I0 error map.
-          I is the cube reconstructed from alpha and I0.
-          c is the restoring beam used for convolution.
-          m is the convolved model.
-          r is the convolved residual.
+          I is the reconstructed cube.
+          d is the difference between the data and the fit.
           b is the average power beam.
-          d is the difference between data and fitted model.
-        default: aeikIcmrbd
-      padding-frac:
+        default: aeikId
+      threshold:
         info:
-          Padding factor for FFT's.
+          Multiple of the residual rms below which pixels are not fitted
         dtype: float
-        default: 0.5
-      dont-convolve:
+        default: 10.0
+      max-dr:
         info:
-          Disable convolution with clean PSF (beam)
-        dtype: bool
-        default: false
-      channel-weights-keyword:
+          Maximum dynamic range used to set the threshold when no rms is available
+        dtype: float
+        default: 1000.0
+      pb-min:
         info:
-          Header for channel weight
-        default: WSCIMWG
-      channel-freqs:
-        info:
-          Optional channel frequencies overriding the fits coordinates.
-        dtype: Optional[List[float]]
-      ref-freq:
-        info:
-          Optional reference frequency to overwrite default taken from fits
-        dtype: Optional[float]
-      out-dtype:
-        info:
-          dtype of output images
-        default: f4
-      add-convolved-residuals:
-        info:
-          Flag to add the convolved residuals to the convolved model
-        dtype: bool
-        default: false
-      ms:
-        info:
-          Optional measurement sets used to get the parallactic angle rotation.
-        dtype: Optional[List[str]]
-      beam-model:
-        info:
-          Beam model to use.
-          For fits files the expected pattern is path/to/beam_folder/name_corr_re.fits and its _im.fits pair.
-          JimBeam is also accepted, in which case the beam comes from katbeam.
-        dtype: Optional[File]
-      sparsify-time:
-        info:
-          Subsample PA by this many integrations when computing PA during beam interpolation.
-        dtype: int
-        default: 10
-      corr-type:
-        info:
-          Correlation type
-        choices:
-        - linear
-        - circular
-        default: linear
-      band:
-        info:
-          Band to use with JimBeam.
-          L, UHF or S
-        default: L
+          Beam floor below which pixels are excluded from the fit
+        dtype: float
+        default: 0.15
       deselect-bands:
         info:
-          Optional bands to discard from the fit.
+          Band ids to exclude from the fit
         dtype: Optional[List[int]]
+      ref-freq:
+        info:
+          Reference frequency in Hz.
+          Defaults to the weighted mean of the band frequencies
+        dtype: Optional[float]
+      timeid:
+        info:
+          Restrict the fit to one time id.
+          Every time id is fitted by default
+        dtype: Optional[int]
+      out-dtype:
+        info:
+          Data type of output.
+          Default is single precision
+        default: f4
+      nthreads:
+        info:
+          Number of threads to use per worker
+        dtype: Optional[int]
     outputs:
       alpha-map:
         dtype: File
         info:
           Fitted spectral index map, written when products contains 'a'.
-        implicit: '{current.output-filename}.alpha.fits'
+        implicit: '{current.output-filename}_time0.alpha.fits'

--- a/src/spimple/cli/__init__.py
+++ b/src/spimple/cli/__init__.py
@@ -31,3 +31,7 @@ app.command(name="binterp")(binterp)
 from spimple.cli.mosaic import mosaic  # noqa: E402
 
 app.command(name="mosaic")(mosaic)
+
+from spimple.cli.init import init  # noqa: E402
+
+app.command(name="init")(init)

--- a/src/spimple/cli/imconv.py
+++ b/src/spimple/cli/imconv.py
@@ -16,7 +16,7 @@ File = NewType("File", Path)
 
 @stimela_cab(
     name="imconv",
-    info="Homogenise resolution with Gaussian convolution",
+    info="Convolve images to a common resolution. Deprecated in favour of spimple init.",
     policies={"pass_missing_as_none": True},
 )
 @stimela_output(
@@ -128,7 +128,8 @@ def imconv(
     ] = False,
 ):
     """
-    Homogenise resolution with Gaussian convolution
+    Convolve images to a common resolution.
+    Deprecated in favour of spimple init.
     """
     if backend == "native" or backend == "auto":
         try:

--- a/src/spimple/cli/init.py
+++ b/src/spimple/cli/init.py
@@ -1,0 +1,267 @@
+from pathlib import Path
+from typing import Annotated, Literal, NewType
+
+import typer
+from hip_cargo import (
+    ListStr,
+    StimelaMeta,
+    parse_list_str,
+    parse_upath,
+    stimela_cab,
+    stimela_output,
+)
+
+Directory = NewType("Directory", Path)
+File = NewType("File", Path)
+
+
+@stimela_cab(
+    name="init",
+    info="Ingest FITS images into a pfb-imaging style datatree",
+    policies={"pass_missing_as_none": True},
+)
+@stimela_output(
+    dtype="Directory",
+    name="datatree",
+    info="Datatree store consumed by spifit and mosaic.",
+    implicit="{current.output-filename}_I.dt",
+)
+def init(
+    images: Annotated[
+        ListStr,
+        typer.Option(
+            ...,
+            parser=parse_list_str,
+            help="List of FITS model or restored image files to ingest",
+        ),
+    ],
+    output_filename: Annotated[
+        File,
+        typer.Option(
+            ...,
+            parser=parse_upath,
+            help="Basename of the output datatree store",
+        ),
+    ],
+    residual: Annotated[
+        ListStr | None,
+        typer.Option(
+            parser=parse_list_str,
+            help="List of FITS residual files matching the images",
+        ),
+    ] = None,
+    psf_pars: Annotated[
+        tuple[float, float, float] | None,
+        typer.Option(
+            help="Target resolution as emaj emin pa in degrees. By default the lowest resolution of the inputs is used",
+        ),
+    ] = None,
+    circ_psf: Annotated[
+        bool,
+        typer.Option(
+            help="Force a circular target beam",
+        ),
+    ] = False,
+    dilate: Annotated[
+        float,
+        typer.Option(
+            help="Safety factor applied when the target resolution is derived from the inputs",
+        ),
+    ] = 1.05,
+    beam_model: Annotated[
+        File | None,
+        typer.Option(
+            parser=parse_upath,
+            help="Primary beam to apply. Use JimBeam, a bds zarr store or a FITS cube",
+        ),
+    ] = None,
+    band: Annotated[
+        Literal["L", "UHF", "S"],
+        typer.Option(
+            help="Band to use with JimBeam. L, UHF or S",
+        ),
+    ] = "L",
+    pb_min: Annotated[
+        float,
+        typer.Option(
+            help="Beam floor below which the intrinsic image is zeroed",
+        ),
+    ] = 0.15,
+    padding_frac: Annotated[
+        float,
+        typer.Option(
+            help="Padding used for the FFT based convolution",
+        ),
+    ] = 0.5,
+    products: Annotated[
+        str,
+        typer.Option(
+            help="Restored products to store. a is apparent. i is intrinsic. k is mixed",
+        ),
+    ] = "aik",
+    channel_weights_keyword: Annotated[
+        str,
+        typer.Option(
+            help="Header keyword supplying the per band weight sum",
+        ),
+    ] = "WSCVWSUM",
+    freq_tol: Annotated[
+        float | None,
+        typer.Option(
+            help="Frequencies within this many Hz are treated as one band",
+        ),
+    ] = None,
+    fits_outputs: Annotated[
+        str,
+        typer.Option(
+            help="Products to render as FITS. Lowercase is MFS and uppercase is a cube",
+        ),
+    ] = "",
+    fits_output_folder: Annotated[
+        Directory | None,
+        typer.Option(
+            parser=parse_upath,
+            help="Folder the rendered FITS are written to",
+        ),
+    ] = None,
+    overwrite: Annotated[
+        bool,
+        typer.Option(
+            help="Replace an existing datatree store",
+        ),
+    ] = False,
+    out_dtype: Annotated[
+        str,
+        typer.Option(
+            help="Data type of output. Default is single precision",
+        ),
+    ] = "f4",
+    nthreads: Annotated[
+        int | None,
+        typer.Option(
+            help="Number of threads to use per worker",
+        ),
+    ] = None,
+    nworkers: Annotated[
+        int,
+        typer.Option(
+            help="Number of workers to use for parallel processing",
+        ),
+    ] = 1,
+    backend: Annotated[
+        Literal["auto", "native", "apptainer", "singularity", "docker", "podman"],
+        typer.Option(
+            help="Execution backend.",
+        ),
+        StimelaMeta(
+            skip=True,
+        ),
+    ] = "auto",
+    always_pull_images: Annotated[
+        bool,
+        typer.Option(
+            help="Always pull container images, even if cached locally.",
+        ),
+        StimelaMeta(
+            skip=True,
+        ),
+    ] = False,
+):
+    """
+    Ingest FITS images into a pfb-imaging style datatree
+    """
+    if backend == "native" or backend == "auto":
+        try:
+            # Pre-flight must_exist for remote URIs before dispatching.
+            from hip_cargo.utils.runner import preflight_remote_must_exist  # noqa: E402
+
+            preflight_remote_must_exist(
+                init,
+                dict(
+                    images=images,
+                    output_filename=output_filename,
+                    residual=residual,
+                    psf_pars=psf_pars,
+                    circ_psf=circ_psf,
+                    dilate=dilate,
+                    beam_model=beam_model,
+                    band=band,
+                    pb_min=pb_min,
+                    padding_frac=padding_frac,
+                    products=products,
+                    channel_weights_keyword=channel_weights_keyword,
+                    freq_tol=freq_tol,
+                    fits_outputs=fits_outputs,
+                    fits_output_folder=fits_output_folder,
+                    overwrite=overwrite,
+                    out_dtype=out_dtype,
+                    nthreads=nthreads,
+                    nworkers=nworkers,
+                ),
+            )
+
+            # Lazy import the core implementation
+            from spimple.core.init import init as init_core  # noqa: E402
+
+            # Call the core function with all parameters
+            init_core(
+                images,
+                output_filename,
+                residual=residual,
+                psf_pars=psf_pars,
+                circ_psf=circ_psf,
+                dilate=dilate,
+                beam_model=beam_model,
+                band=band,
+                pb_min=pb_min,
+                padding_frac=padding_frac,
+                products=products,
+                channel_weights_keyword=channel_weights_keyword,
+                freq_tol=freq_tol,
+                fits_outputs=fits_outputs,
+                fits_output_folder=fits_output_folder,
+                overwrite=overwrite,
+                out_dtype=out_dtype,
+                nthreads=nthreads,
+                nworkers=nworkers,
+            )
+            return
+        except ImportError:
+            if backend == "native":
+                raise
+
+    # Resolve container image from installed package metadata
+    from hip_cargo.utils.config import get_container_image  # noqa: E402
+    from hip_cargo.utils.runner import run_in_container  # noqa: E402
+
+    image = get_container_image("spimple")
+    if image is None:
+        raise RuntimeError("No Container URL in spimple metadata.")
+
+    run_in_container(
+        init,
+        dict(
+            images=images,
+            output_filename=output_filename,
+            residual=residual,
+            psf_pars=psf_pars,
+            circ_psf=circ_psf,
+            dilate=dilate,
+            beam_model=beam_model,
+            band=band,
+            pb_min=pb_min,
+            padding_frac=padding_frac,
+            products=products,
+            channel_weights_keyword=channel_weights_keyword,
+            freq_tol=freq_tol,
+            fits_outputs=fits_outputs,
+            fits_output_folder=fits_output_folder,
+            overwrite=overwrite,
+            out_dtype=out_dtype,
+            nthreads=nthreads,
+            nworkers=nworkers,
+        ),
+        image=image,
+        backend=backend,
+        always_pull_images=always_pull_images,
+    )

--- a/src/spimple/cli/mosaic.py
+++ b/src/spimple/cli/mosaic.py
@@ -2,116 +2,82 @@ from pathlib import Path
 from typing import Annotated, Literal, NewType
 
 import typer
-from hip_cargo import (
-    ListStr,
-    StimelaMeta,
-    parse_list_str,
-    parse_upath,
-    stimela_cab,
-    stimela_output,
-)
+from hip_cargo import StimelaMeta, parse_upath, stimela_cab, stimela_output
 
+Directory = NewType("Directory", Path)
 File = NewType("File", Path)
 
 
 @stimela_cab(
     name="mosaic",
-    info="Reproject and combine multiple images into a mosaic.",
+    info="Combine the partitions of a datatree into band mean images.",
     policies={"pass_missing_as_none": True},
 )
 @stimela_output(
-    dtype="File",
-    name="mosaic-image",
-    info="Mosaicked image on the common coordinate grid.",
-    implicit="{current.output-filename}",
+    dtype="Directory",
+    name="datatree",
+    info="Datatree store with the band mean images populated.",
+    implicit="{current.store}",
 )
 def mosaic(
-    images: Annotated[
-        ListStr,
+    store: Annotated[
+        Directory,
         typer.Option(
             ...,
-            parser=parse_list_str,
-            help="List of FITS images to mosaic together",
+            parser=parse_upath,
+            help="Datatree store written by spimple init",
         ),
     ],
     output_filename: Annotated[
-        File,
-        typer.Option(
-            ...,
-            parser=parse_upath,
-            help="Path of the output mosaic FITS file",
-        ),
-    ],
-    beam_model: Annotated[
         File | None,
         typer.Option(
             parser=parse_upath,
-            help="Beam dataset to apply. Use binterp to make a power beam matching the images.",
+            help="Basename for the rendered FITS files",
         ),
     ] = None,
-    band: Annotated[
-        str,
-        typer.Option(
-            help="Band to use with JimBeam. L, UHF or S",
-        ),
-    ] = "L",
-    ref_image: Annotated[
-        File | None,
-        typer.Option(
-            parser=parse_upath,
-            help="Reference image defining the output coordinate system. "
-            "An optimal reference is derived when this is not provided.",
-        ),
-    ] = None,
-    padding: Annotated[
+    eta: Annotated[
         float,
         typer.Option(
-            help="Padding factor for FFTs.",
+            help="Tikhonov floor keeping the solve finite where no partition covers",
         ),
-    ] = 0.1,
-    method: Annotated[
-        Literal["interp", "adaptive", "exact"],
+    ] = 0.001,
+    products: Annotated[
+        str,
         typer.Option(
-            help="Reprojection method, see reproject for details.",
+            help="Products to combine. a is apparent. i is intrinsic. k is mixed",
         ),
-    ] = "interp",
-    nthreads: Annotated[
-        int,
+    ] = "aik",
+    fits_outputs: Annotated[
+        str,
         typer.Option(
-            help="Number of threads to use per worker.",
+            help="Products to render as FITS. Lowercase is MFS and uppercase is a cube",
         ),
-    ] = 1,
-    nworkers: Annotated[
-        int,
+    ] = "I",
+    fits_output_folder: Annotated[
+        Directory | None,
         typer.Option(
-            help="Number of workers to use for parallel processing.",
+            parser=parse_upath,
+            help="Folder the rendered FITS are written to",
         ),
-    ] = 1,
+    ] = None,
     out_dtype: Annotated[
         str,
         typer.Option(
             help="Data type of output. Default is single precision",
         ),
     ] = "f4",
-    convolve: Annotated[
-        bool,
+    nthreads: Annotated[
+        int | None,
         typer.Option(
-            help="Flag to convolve images to common resolution before projection. "
-            "If no psf-pars are passed in the lowest resolution will be determined automatically.",
+            help="Number of threads to use per worker",
         ),
-    ] = False,
-    redo_project: Annotated[
-        bool,
+    ] = None,
+    nworkers: Annotated[
+        int,
         typer.Option(
-            help="Force re-projection even if output exists.",
+            help="Number of workers to use for parallel processing",
         ),
-    ] = False,
-    debug: Annotated[
-        bool,
-        typer.Option(
-            help="Run everything in local mode to assist with debugging.",
-        ),
-    ] = False,
+    ] = 1,
     backend: Annotated[
         Literal["auto", "native", "apptainer", "singularity", "docker", "podman"],
         typer.Option(
@@ -132,7 +98,7 @@ def mosaic(
     ] = False,
 ):
     """
-    Reproject and combine multiple images into a mosaic.
+    Combine the partitions of a datatree into band mean images.
     """
     if backend == "native" or backend == "auto":
         try:
@@ -142,19 +108,15 @@ def mosaic(
             preflight_remote_must_exist(
                 mosaic,
                 dict(
-                    images=images,
+                    store=store,
                     output_filename=output_filename,
-                    beam_model=beam_model,
-                    band=band,
-                    ref_image=ref_image,
-                    padding=padding,
-                    method=method,
+                    eta=eta,
+                    products=products,
+                    fits_outputs=fits_outputs,
+                    fits_output_folder=fits_output_folder,
+                    out_dtype=out_dtype,
                     nthreads=nthreads,
                     nworkers=nworkers,
-                    out_dtype=out_dtype,
-                    convolve=convolve,
-                    redo_project=redo_project,
-                    debug=debug,
                 ),
             )
 
@@ -163,19 +125,15 @@ def mosaic(
 
             # Call the core function with all parameters
             mosaic_core(
-                images,
-                output_filename,
-                beam_model=beam_model,
-                band=band,
-                ref_image=ref_image,
-                padding=padding,
-                method=method,
+                store,
+                output_filename=output_filename,
+                eta=eta,
+                products=products,
+                fits_outputs=fits_outputs,
+                fits_output_folder=fits_output_folder,
+                out_dtype=out_dtype,
                 nthreads=nthreads,
                 nworkers=nworkers,
-                out_dtype=out_dtype,
-                convolve=convolve,
-                redo_project=redo_project,
-                debug=debug,
             )
             return
         except ImportError:
@@ -193,19 +151,15 @@ def mosaic(
     run_in_container(
         mosaic,
         dict(
-            images=images,
+            store=store,
             output_filename=output_filename,
-            beam_model=beam_model,
-            band=band,
-            ref_image=ref_image,
-            padding=padding,
-            method=method,
+            eta=eta,
+            products=products,
+            fits_outputs=fits_outputs,
+            fits_output_folder=fits_output_folder,
+            out_dtype=out_dtype,
             nthreads=nthreads,
             nworkers=nworkers,
-            out_dtype=out_dtype,
-            convolve=convolve,
-            redo_project=redo_project,
-            debug=debug,
         ),
         image=image,
         backend=backend,

--- a/src/spimple/cli/spifit.py
+++ b/src/spimple/cli/spifit.py
@@ -3,39 +3,36 @@ from typing import Annotated, Literal, NewType
 
 import typer
 from hip_cargo import (
-    ListFloat,
     ListInt,
-    ListStr,
     StimelaMeta,
-    parse_list_float,
     parse_list_int,
-    parse_list_str,
     parse_upath,
     stimela_cab,
     stimela_output,
 )
 
+Directory = NewType("Directory", Path)
 File = NewType("File", Path)
 
 
 @stimela_cab(
     name="spifit",
-    info="Fit spectral index map.",
+    info="Fit a spectral index model to the band images of a datatree.",
     policies={"pass_missing_as_none": True},
 )
 @stimela_output(
     dtype="File",
     name="alpha-map",
     info="Fitted spectral index map, written when products contains 'a'.",
-    implicit="{current.output-filename}.alpha.fits",
+    implicit="{current.output-filename}_time0.alpha.fits",
 )
 def spifit(
-    images: Annotated[
-        ListStr,
+    store: Annotated[
+        Directory,
         typer.Option(
             ...,
-            parser=parse_list_str,
-            help="Images to process",
+            parser=parse_upath,
+            help="Datatree store to fit. Written by spimple init or by pfb-imaging",
         ),
     ],
     output_filename: Annotated[
@@ -43,152 +40,75 @@ def spifit(
         typer.Option(
             ...,
             parser=parse_upath,
-            help="Basename of output products",
+            help="Basename of the output FITS products",
         ),
     ],
-    residual: Annotated[
-        ListStr | None,
+    flux_scale: Annotated[
+        Literal["apparent", "intrinsic", "mixed"],
         typer.Option(
-            parser=parse_list_str,
-            help="Residual images matching the input images",
+            help="Flux scale to fit. Apparent uses BIMAGE. Intrinsic uses IMAGE. Mixed uses KIMAGE",
         ),
-    ] = None,
-    psf_pars: Annotated[
-        tuple[float, float, float] | None,
-        typer.Option(
-            help="PSF (beam) parameters matching FWHM of restoring beam specified as emaj emin pa. "
-            "Taken from the fits header by default.",
-        ),
-    ] = None,
-    circ_psf: Annotated[
-        bool,
-        typer.Option(
-            help="Flag to use circular restoring PSF (beam)",
-        ),
-    ] = False,
-    threshold: Annotated[
-        float,
-        typer.Option(
-            help="Multiple of the rms in the residual to threshold on. "
-            "Only components above threshold*rms will be fit.",
-        ),
-    ] = 10,
-    max_dr: Annotated[
-        float,
-        typer.Option(
-            help="Maximum dynamic range used to determine the threshold. Only used when residual is not available.",
-        ),
-    ] = 1000,
-    nthreads: Annotated[
-        int | None,
-        typer.Option(
-            help="Number of threads to use. Defaults to all",
-        ),
-    ] = None,
-    pb_min: Annotated[
-        float,
-        typer.Option(
-            help="Don't fit components where the primary beam is less than this",
-        ),
-    ] = 0.15,
+    ] = "apparent",
     products: Annotated[
         str,
         typer.Option(
-            help="Outputs to write, as a string of letters. "
+            help="Products to write, as a string of letters. "
             "a is the alpha map. "
             "e is the alpha error map. "
             "i is the I0 map. "
             "k is the I0 error map. "
-            "I is the cube reconstructed from alpha and I0. "
-            "c is the restoring beam used for convolution. "
-            "m is the convolved model. "
-            "r is the convolved residual. "
-            "b is the average power beam. "
-            "d is the difference between data and fitted model.",
+            "I is the reconstructed cube. "
+            "d is the difference between the data and the fit. "
+            "b is the average power beam.",
         ),
-    ] = "aeikIcmrbd",
-    padding_frac: Annotated[
+    ] = "aeikId",
+    threshold: Annotated[
         float,
         typer.Option(
-            help="Padding factor for FFT's.",
+            help="Multiple of the residual rms below which pixels are not fitted",
         ),
-    ] = 0.5,
-    dont_convolve: Annotated[
-        bool,
+    ] = 10.0,
+    max_dr: Annotated[
+        float,
         typer.Option(
-            help="Disable convolution with clean PSF (beam)",
+            help="Maximum dynamic range used to set the threshold when no rms is available",
         ),
-    ] = False,
-    channel_weights_keyword: Annotated[
-        str,
+    ] = 1000.0,
+    pb_min: Annotated[
+        float,
         typer.Option(
-            help="Header for channel weight",
+            help="Beam floor below which pixels are excluded from the fit",
         ),
-    ] = "WSCIMWG",
-    channel_freqs: Annotated[
-        ListFloat | None,
+    ] = 0.15,
+    deselect_bands: Annotated[
+        ListInt | None,
         typer.Option(
-            parser=parse_list_float,
-            help="Optional channel frequencies overriding the fits coordinates.",
+            parser=parse_list_int,
+            help="Band ids to exclude from the fit",
         ),
     ] = None,
     ref_freq: Annotated[
         float | None,
         typer.Option(
-            help="Optional reference frequency to overwrite default taken from fits",
+            help="Reference frequency in Hz. Defaults to the weighted mean of the band frequencies",
+        ),
+    ] = None,
+    timeid: Annotated[
+        int | None,
+        typer.Option(
+            help="Restrict the fit to one time id. Every time id is fitted by default",
         ),
     ] = None,
     out_dtype: Annotated[
         str,
         typer.Option(
-            help="dtype of output images",
+            help="Data type of output. Default is single precision",
         ),
     ] = "f4",
-    add_convolved_residuals: Annotated[
-        bool,
+    nthreads: Annotated[
+        int | None,
         typer.Option(
-            help="Flag to add the convolved residuals to the convolved model",
-        ),
-    ] = False,
-    ms: Annotated[
-        ListStr | None,
-        typer.Option(
-            parser=parse_list_str,
-            help="Optional measurement sets used to get the parallactic angle rotation.",
-        ),
-    ] = None,
-    beam_model: Annotated[
-        File | None,
-        typer.Option(
-            parser=parse_upath,
-            help="Beam model to use. "
-            "For fits files the expected pattern is path/to/beam_folder/name_corr_re.fits and its _im.fits pair. "
-            "JimBeam is also accepted, in which case the beam comes from katbeam.",
-        ),
-    ] = None,
-    sparsify_time: Annotated[
-        int,
-        typer.Option(
-            help="Subsample PA by this many integrations when computing PA during beam interpolation.",
-        ),
-    ] = 10,
-    corr_type: Annotated[
-        Literal["linear", "circular"],
-        typer.Option(
-            help="Correlation type",
-        ),
-    ] = "linear",
-    band: Annotated[
-        str,
-        typer.Option(
-            help="Band to use with JimBeam. L, UHF or S",
-        ),
-    ] = "L",
-    deselect_bands: Annotated[
-        ListInt | None,
-        typer.Option(
-            parser=parse_list_int,
-            help="Optional bands to discard from the fit.",
+            help="Number of threads to use per worker",
         ),
     ] = None,
     backend: Annotated[
@@ -211,7 +131,7 @@ def spifit(
     ] = False,
 ):
     """
-    Fit spectral index map.
+    Fit a spectral index model to the band images of a datatree.
     """
     if backend == "native" or backend == "auto":
         try:
@@ -221,29 +141,18 @@ def spifit(
             preflight_remote_must_exist(
                 spifit,
                 dict(
-                    images=images,
+                    store=store,
                     output_filename=output_filename,
-                    residual=residual,
-                    psf_pars=psf_pars,
-                    circ_psf=circ_psf,
+                    flux_scale=flux_scale,
+                    products=products,
                     threshold=threshold,
                     max_dr=max_dr,
-                    nthreads=nthreads,
                     pb_min=pb_min,
-                    products=products,
-                    padding_frac=padding_frac,
-                    dont_convolve=dont_convolve,
-                    channel_weights_keyword=channel_weights_keyword,
-                    channel_freqs=channel_freqs,
-                    ref_freq=ref_freq,
-                    out_dtype=out_dtype,
-                    add_convolved_residuals=add_convolved_residuals,
-                    ms=ms,
-                    beam_model=beam_model,
-                    sparsify_time=sparsify_time,
-                    corr_type=corr_type,
-                    band=band,
                     deselect_bands=deselect_bands,
+                    ref_freq=ref_freq,
+                    timeid=timeid,
+                    out_dtype=out_dtype,
+                    nthreads=nthreads,
                 ),
             )
 
@@ -252,29 +161,18 @@ def spifit(
 
             # Call the core function with all parameters
             spifit_core(
-                images,
+                store,
                 output_filename,
-                residual=residual,
-                psf_pars=psf_pars,
-                circ_psf=circ_psf,
+                flux_scale=flux_scale,
+                products=products,
                 threshold=threshold,
                 max_dr=max_dr,
-                nthreads=nthreads,
                 pb_min=pb_min,
-                products=products,
-                padding_frac=padding_frac,
-                dont_convolve=dont_convolve,
-                channel_weights_keyword=channel_weights_keyword,
-                channel_freqs=channel_freqs,
-                ref_freq=ref_freq,
-                out_dtype=out_dtype,
-                add_convolved_residuals=add_convolved_residuals,
-                ms=ms,
-                beam_model=beam_model,
-                sparsify_time=sparsify_time,
-                corr_type=corr_type,
-                band=band,
                 deselect_bands=deselect_bands,
+                ref_freq=ref_freq,
+                timeid=timeid,
+                out_dtype=out_dtype,
+                nthreads=nthreads,
             )
             return
         except ImportError:
@@ -292,29 +190,18 @@ def spifit(
     run_in_container(
         spifit,
         dict(
-            images=images,
+            store=store,
             output_filename=output_filename,
-            residual=residual,
-            psf_pars=psf_pars,
-            circ_psf=circ_psf,
+            flux_scale=flux_scale,
+            products=products,
             threshold=threshold,
             max_dr=max_dr,
-            nthreads=nthreads,
             pb_min=pb_min,
-            products=products,
-            padding_frac=padding_frac,
-            dont_convolve=dont_convolve,
-            channel_weights_keyword=channel_weights_keyword,
-            channel_freqs=channel_freqs,
-            ref_freq=ref_freq,
-            out_dtype=out_dtype,
-            add_convolved_residuals=add_convolved_residuals,
-            ms=ms,
-            beam_model=beam_model,
-            sparsify_time=sparsify_time,
-            corr_type=corr_type,
-            band=band,
             deselect_bands=deselect_bands,
+            ref_freq=ref_freq,
+            timeid=timeid,
+            out_dtype=out_dtype,
+            nthreads=nthreads,
         ),
         image=image,
         backend=backend,

--- a/src/spimple/cli/spifit.py
+++ b/src/spimple/cli/spifit.py
@@ -46,9 +46,10 @@ def spifit(
     flux_scale: Annotated[
         Literal["apparent", "intrinsic", "mixed"],
         typer.Option(
+            ...,
             help="Flux scale to fit. Apparent uses BIMAGE. Intrinsic uses IMAGE. Mixed uses KIMAGE",
         ),
-    ] = "apparent",
+    ],
     products: Annotated[
         str,
         typer.Option(
@@ -163,7 +164,7 @@ def spifit(
             spifit_core(
                 store,
                 output_filename,
-                flux_scale=flux_scale,
+                flux_scale,
                 products=products,
                 threshold=threshold,
                 max_dr=max_dr,

--- a/src/spimple/core/imconv.py
+++ b/src/spimple/core/imconv.py
@@ -30,6 +30,11 @@ def imconv(
 ):
     log_options(log, **locals())
 
+    log.warning(
+        "imconv is deprecated and will be removed in a future release. "
+        "Use spimple init, which convolves to a common resolution while building the datatree."
+    )
+
     images = expand_image_patterns(images)
 
     if not nthreads:

--- a/src/spimple/core/init.py
+++ b/src/spimple/core/init.py
@@ -14,7 +14,9 @@ from pathlib import Path
 import numpy as np
 from astropy.io import fits
 from astropy.time import Time
+from astropy.wcs import WCS
 
+from spimple.utils.beamsource import beam_for_grid
 from spimple.utils.datatree import (
     PRODUCT_VARS,
     band_node_name,
@@ -25,6 +27,7 @@ from spimple.utils.datatree import (
 )
 from spimple.utils.fits import data_from_header, expand_image_patterns, freq_axis_of, load_cube
 from spimple.utils.logging import get_logger, log_options
+from spimple.utils.project import reproject_cube, union_wcs
 from spimple.utils.render import dt2fits
 from spimple.utils.restoration import restore_products
 
@@ -268,25 +271,33 @@ def init(
         nthreads = multiprocessing.cpu_count()
 
     groups = group_partitions(images)
-    if len(groups) > 1:
-        raise NotImplementedError(f"{len(groups)} partitions found; multi-pointing ingest is not implemented yet")
-    if beam_model is not None:
-        raise NotImplementedError("beam models are not implemented yet; run without beam-model")
 
-    part_paths = groups[0][1]
-    hdr = fits.getheader(part_paths[0])
-    corr = stokes_labels(hdr)
+    headers = [fits.getheader(paths[0]) for _, paths in groups]
+    ref_hdr = headers[0]
+    corr = stokes_labels(ref_hdr)
     ncorr = len(corr)
-    cell_deg = abs(float(hdr["CDELT1"]))
+    cell_deg = abs(float(ref_hdr["CDELT1"]))
     cell_rad = np.deg2rad(cell_deg)
-    ny, nx = int(hdr["NAXIS2"]), int(hdr["NAXIS1"])
     product = "".join(corr)
 
-    nominal, mapping = assign_bands([frequencies_of(part_paths)], freq_tol)
+    target_wcs, (ny, nx) = union_wcs(headers)
+    ra = np.deg2rad(float(target_wcs.wcs.crval[0]))
+    dec = np.deg2rad(float(target_wcs.wcs.crval[1]))
+    log.info("Union grid is %d by %d pixels over %d partitions", ny, nx, len(groups))
+
+    residual_groups = group_partitions(residual) if residual else None
+    if residual_groups is not None and len(residual_groups) != len(groups):
+        raise ValueError(
+            f"{len(groups)} image partitions but {len(residual_groups)} residual partitions; "
+            "they must describe the same pointings"
+        )
+
+    freqs_per_partition = [frequencies_of(paths) for _, paths in groups]
+    nominal, mapping = assign_bands(freqs_per_partition, freq_tol)
     nband = nominal.size
 
-    psfparsn = psfpars_from_header(hdr, nband, ncorr, cell_deg)
-    target = resolve_target(psfparsn, psf_pars, circ_psf, dilate, cell_deg)
+    psfparsn = [psfpars_from_header(hdr, nband, ncorr, cell_deg) for hdr in headers]
+    target = resolve_target(np.concatenate(psfparsn, axis=0), psf_pars, circ_psf, dilate, cell_deg)
     log.info(
         "Target resolution %.3e deg by %.3e deg at %.3e deg",
         target[0, 0] * cell_deg,
@@ -302,88 +313,109 @@ def init(
             "product": product,
             "nband": int(nband),
             "ntime": 1,
-            "nx": nx,
-            "ny": ny,
+            "nx": int(nx),
+            "ny": int(ny),
             "cell_rad": cell_rad,
             "origin": "spimple-init",
         },
         overwrite=overwrite,
     )
 
-    beam = np.ones((ncorr, ny, nx), dtype=np.float64)
-    rhdr = fits.getheader(residual[0]) if residual else hdr
-    time_out = _time_out(hdr)
-    ra, dec = np.deg2rad(float(hdr["CRVAL1"])), np.deg2rad(float(hdr["CRVAL2"]))
     letters = tuple(k for k in ("a", "i", "k") if k in products)
+    single = len(groups) == 1
 
-    for bandid in range(nband):
-        chan = mapping[0].get(bandid)
-        if chan is None:
-            continue
-        model = _read_band(part_paths, bandid, chan)
-        if residual:
-            resid = _read_band(residual, bandid, chan)
-        else:
-            # no residual: the input is a restored image, so it carries the
-            # resolution and there is no separate model to convolve
-            resid = model
-            model = np.zeros_like(resid)
+    for pid, (_, paths) in enumerate(groups):
+        hdr = headers[pid]
+        part_wcs = WCS(hdr).celestial
+        part_shape = (int(hdr["NAXIS2"]), int(hdr["NAXIS1"]))
+        res_paths = residual_groups[pid][1] if residual_groups else None
+        rhdr = fits.getheader(res_paths[0]) if res_paths else hdr
+        band_ids = sorted(mapping[pid])
+        band_freqs = np.array([freqs_per_partition[pid][mapping[pid][b]] for b in band_ids], dtype=float)
+        beams = beam_for_grid(beam_model, band, band_freqs, part_wcs, part_shape, ncorr, nthreads=nthreads)
+        ra0 = np.deg2rad(float(hdr["CRVAL1"]))
+        dec0 = np.deg2rad(float(hdr["CRVAL2"]))
 
-        out = restore_products(
-            model,
-            resid,
-            beam,
-            target,
-            gausspari=psfparsn[bandid],
-            products=letters,
-            pb_min=pb_min,
-            nthreads=nthreads,
-            padding_frac=padding_frac,
-        )
+        for slot, bandid in enumerate(band_ids):
+            chan = mapping[pid][bandid]
+            model = _read_band(paths, bandid, chan)
+            if res_paths:
+                resid = _read_band(res_paths, bandid, chan)
+            else:
+                # no residual: the input is a restored image, so it carries the
+                # resolution and there is no separate model to convolve
+                resid = model
+                model = np.zeros_like(resid)
+            beam = beams[slot]
 
-        rms = np.array([float(np.std(resid[c])) for c in range(ncorr)])
-        if channel_weights_keyword in rhdr:
-            wsum = np.full(ncorr, float(rhdr[channel_weights_keyword]))
-        else:
-            wsum = np.where(rms > 0, 1.0 / np.maximum(rms, 1e-30) ** 2, 1.0)
+            out = restore_products(
+                model,
+                resid,
+                beam,
+                target,
+                gausspari=psfparsn[pid][bandid],
+                products=letters,
+                pb_min=pb_min,
+                nthreads=nthreads,
+                padding_frac=padding_frac,
+            )
 
-        data_vars = {PRODUCT_VARS[k]: (("corr", "y", "x"), out[k].astype(out_dtype)) for k in letters}
-        data_vars["BEAM"] = (("corr", "y", "x"), beam.astype(out_dtype))
-        data_vars["WSUM"] = (("corr",), wsum.astype(np.float64))
-        data_vars["RMS"] = (("corr",), rms.astype(np.float64))
-        data_vars["PSFPARSF"] = (("corr", "bpar"), target.astype(np.float64))
-        attrs = {
-            "bandid": int(bandid),
-            "timeid": 0,
-            "freq_out": float(nominal[bandid]),
-            "freq_nominal": float(nominal[bandid]),
-            "time_out": time_out,
-            "ra": ra,
-            "dec": dec,
-            "cell_rad": cell_rad,
-            "l0": 0.0,
-            "m0": 0.0,
-            "pb_min": float(pb_min),
-        }
-        coords = {"corr": corr, "bpar": BPAR}
-        node = band_node_name(bandid, 0)
-        # one partition: the band product IS the partition product, so write both
-        write_node(
-            url,
-            f"{node}/{partition_node_name(0)}",
-            {**data_vars, "MASK": (("corr", "y", "x"), np.ones((ncorr, ny, nx), dtype=bool))},
-            {
-                "field_name": field_name_for(part_paths, 0),
-                "ra0": ra,
-                "dec0": dec,
+            rms = np.array([float(np.std(resid[c])) for c in range(ncorr)])
+            if channel_weights_keyword in rhdr:
+                wsum = np.full(ncorr, float(rhdr[channel_weights_keyword]))
+            else:
+                wsum = np.where(rms > 0, 1.0 / np.maximum(rms, 1e-30) ** 2, 1.0)
+
+            # Convolve first, reproject second: the products are Jy/beam, which
+            # reproject_interp conserves. A Jy/pixel model would not survive it.
+            # The beam goes first so the footprint mask is defined even when
+            # products selects nothing.
+            pbeam, mask = reproject_cube(beam, part_wcs, target_wcs, (ny, nx))
+            pbeam[:, ~mask] = 0.0
+            projected = {k: reproject_cube(arr, part_wcs, target_wcs, (ny, nx))[0] for k, arr in out.items()}
+
+            data_vars = {PRODUCT_VARS[k]: (("corr", "y", "x"), projected[k].astype(out_dtype)) for k in letters}
+            data_vars["BEAM"] = (("corr", "y", "x"), pbeam.astype(out_dtype))
+            data_vars["WSUM"] = (("corr",), wsum.astype(np.float64))
+            data_vars["RMS"] = (("corr",), rms.astype(np.float64))
+            data_vars["PSFPARSF"] = (("corr", "bpar"), target.astype(np.float64))
+            coords = {"corr": corr, "bpar": BPAR}
+            node = band_node_name(bandid, 0)
+
+            write_node(
+                url,
+                f"{node}/{partition_node_name(pid)}",
+                {**data_vars, "MASK": (("corr", "y", "x"), np.repeat(mask[None], ncorr, axis=0))},
+                {
+                    "field_name": field_name_for(paths, pid),
+                    "ra0": ra0,
+                    "dec0": dec0,
+                    "freq_out": float(nominal[bandid]),
+                    "psfparsn": psfparsn[pid][bandid].tolist(),
+                    "beam_includes_n": False,
+                },
+                coords,
+            )
+            attrs = {
+                "bandid": int(bandid),
+                "timeid": 0,
                 "freq_out": float(nominal[bandid]),
-                "psfparsn": psfparsn[bandid].tolist(),
-                "beam_includes_n": False,
-            },
-            coords,
-        )
-        write_node(url, node, data_vars, attrs, coords)
-        log.info("Wrote band %d at %.4e Hz", bandid, nominal[bandid])
+                "freq_nominal": float(nominal[bandid]),
+                "time_out": _time_out(hdr),
+                "ra": ra,
+                "dec": dec,
+                "cell_rad": cell_rad,
+                "l0": 0.0,
+                "m0": 0.0,
+                "pb_min": float(pb_min),
+            }
+            if single:
+                # one pointing needs no mosaic step: the band product IS the
+                # partition product, so write it straight through
+                write_node(url, node, data_vars, attrs, coords)
+            else:
+                write_node(url, node, {"PSFPARSF": data_vars["PSFPARSF"]}, attrs, coords)
+        log.info("Wrote partition %d with %d bands", pid, len(band_ids))
 
     if fits_outputs:
         folder = fits_output_folder or str(Path(url).parent / "fits")

--- a/src/spimple/core/init.py
+++ b/src/spimple/core/init.py
@@ -1,0 +1,137 @@
+"""Ingest FITS images into a pfb-imaging-style DataTree.
+
+Input files are grouped into partitions by phase centre and grid, and into bands
+by frequency. Each partition is homogenised to a common resolution and, when
+there is more than one, reprojected onto a union grid. See
+``docs/wiki/datatree-contract.md``.
+"""
+
+import os
+import re
+
+import numpy as np
+from astropy.io import fits
+
+from spimple.utils.datatree import partition_node_name
+from spimple.utils.fits import data_from_header, freq_axis_of
+
+PartitionKey = tuple[float, float, float, float, int, int]
+
+# a thousandth of a pixel, so floating-point noise in a header never splits a partition
+_CELL_FRACTION = 1e-3
+
+
+def partition_key(hdr) -> PartitionKey:
+    """Return the identity of the partition a FITS header belongs to.
+
+    Files sharing a phase centre and an image grid are one pointing and become
+    one partition. The celestial values are rounded to a thousandth of a pixel
+    so header round-tripping cannot split a partition.
+
+    Args:
+        hdr: FITS header.
+
+    Returns:
+        A hashable key of (crval1, crval2, cdelt1, cdelt2, naxis1, naxis2).
+    """
+    cell = abs(float(hdr["CDELT1"]))
+    quantum = cell * _CELL_FRACTION
+    return (
+        round(float(hdr["CRVAL1"]) / quantum) * quantum,
+        round(float(hdr["CRVAL2"]) / quantum) * quantum,
+        round(float(hdr["CDELT1"]) / quantum) * quantum,
+        round(float(hdr["CDELT2"]) / quantum) * quantum,
+        int(hdr["NAXIS1"]),
+        int(hdr["NAXIS2"]),
+    )
+
+
+def group_partitions(paths: list[str]) -> list[tuple[PartitionKey, list[str]]]:
+    """Group input paths into partitions, ordered by phase centre.
+
+    Args:
+        paths: Resolved FITS paths.
+
+    Returns:
+        A list of (key, paths) pairs sorted by (ra0, dec0), so partition ids are
+        deterministic across runs.
+    """
+    groups: dict[PartitionKey, list[str]] = {}
+    for path in paths:
+        groups.setdefault(partition_key(fits.getheader(path)), []).append(path)
+    return [(key, sorted(groups[key])) for key in sorted(groups, key=lambda k: (k[0], k[1]))]
+
+
+def frequencies_of(paths: list[str]) -> np.ndarray:
+    """Return the sorted distinct channel frequencies across a partition's files."""
+    freqs: list[float] = []
+    for path in paths:
+        hdr = fits.getheader(path)
+        values, _ = data_from_header(hdr, axis=freq_axis_of(hdr))
+        freqs.extend(np.atleast_1d(values).tolist())
+    return np.array(sorted(freqs), dtype=np.float64)
+
+
+def assign_bands(
+    freqs_per_partition: list[np.ndarray], freq_tol: float | None
+) -> tuple[np.ndarray, list[dict[int, int]]]:
+    """Cluster every partition's channels into a common set of bands.
+
+    Args:
+        freqs_per_partition: One ascending frequency array per partition.
+        freq_tol: Frequencies within this many Hz are one band. Defaults to half
+            the narrowest channel width present, or 1 Hz for single-channel input.
+
+    Returns:
+        The (nband,) nominal band frequencies (each cluster's midpoint), and one
+        dict per partition mapping bandid to that partition's channel index.
+
+    Raises:
+        ValueError: If a partition would contribute two channels to one band.
+    """
+    every = np.sort(np.concatenate([np.atleast_1d(f) for f in freqs_per_partition]))
+    if freq_tol is None:
+        widths = [np.diff(np.atleast_1d(f)) for f in freqs_per_partition]
+        widths = np.concatenate([w for w in widths if w.size]) if any(w.size for w in widths) else np.array([2.0])
+        freq_tol = float(np.min(np.abs(widths))) / 2.0
+
+    # single linkage: start a new cluster wherever the gap exceeds the tolerance
+    edges = np.flatnonzero(np.diff(every) > freq_tol) + 1
+    clusters = np.split(every, edges)
+    nominal = np.array([0.5 * (c[0] + c[-1]) for c in clusters], dtype=np.float64)
+
+    mapping: list[dict[int, int]] = []
+    for pid, freqs in enumerate(freqs_per_partition):
+        per_partition: dict[int, int] = {}
+        for chan, freq in enumerate(np.atleast_1d(freqs)):
+            bandid = int(np.argmin(np.abs(nominal - freq)))
+            if bandid in per_partition:
+                raise ValueError(
+                    f"partition {pid} contributes two channels to band {bandid} "
+                    f"({freq:.6g} Hz and {np.atleast_1d(freqs)[per_partition[bandid]]:.6g} Hz); "
+                    "lower freq-tol to separate them"
+                )
+            per_partition[bandid] = chan
+        mapping.append(per_partition)
+    return nominal, mapping
+
+
+def field_name_for(paths: list[str], pid: int) -> str:
+    """Name a partition after the common prefix of its filenames.
+
+    Args:
+        paths: The partition's file paths.
+        pid: Partition id, used for the fallback.
+
+    Returns:
+        The stripped common prefix of the basenames, or the partition node name
+        when there is no useful prefix.
+    """
+    # drop the extension first, or a single-file partition keeps its ".fits"
+    names = [os.path.splitext(os.path.basename(p))[0] for p in paths]
+    prefix = os.path.commonprefix(names)
+    # commonprefix is character-wise, so "deep2-0000-image" and "deep2-0001-image"
+    # give "deep2-000". Strip a separator-prefixed digit run -- never a bare one,
+    # or a field genuinely named "deep2" would lose its 2.
+    prefix = re.sub(r"[-_.]\d*$", "", prefix).rstrip("-_. ")
+    return prefix if prefix else partition_node_name(pid)

--- a/src/spimple/core/init.py
+++ b/src/spimple/core/init.py
@@ -84,13 +84,20 @@ def group_partitions(paths: list[str]) -> list[tuple[PartitionKey, list[str]]]:
 
 
 def frequencies_of(paths: list[str]) -> np.ndarray:
-    """Return the sorted distinct channel frequencies across a partition's files."""
+    """Return a partition's channel frequencies in traversal order.
+
+    Deliberately NOT sorted. The returned index of each frequency is what
+    ``assign_bands`` records in its mapping and what ``_locate_band`` then uses
+    to find the plane, so it must be the order those two walk: files in the
+    given order, planes in native cube-axis order. Sorting here silently
+    mislabels every plane of a descending frequency axis.
+    """
     freqs: list[float] = []
     for path in paths:
         hdr = fits.getheader(path)
         values, _ = data_from_header(hdr, axis=freq_axis_of(hdr))
         freqs.extend(np.atleast_1d(values).tolist())
-    return np.array(sorted(freqs), dtype=np.float64)
+    return np.array(freqs, dtype=np.float64)
 
 
 def assign_bands(
@@ -179,18 +186,25 @@ def store_name(output_filename: str, product: str) -> str:
     return f"{output_filename}_{product.upper()}.dt"
 
 
-def resolve_target(psfparsn, psf_pars, circ_psf: bool, dilate: float, cell_deg: float) -> np.ndarray:
+def resolve_target(psfparsn, psf_pars, circ_psf: bool, dilate: float, cell_deg: float = 1.0) -> np.ndarray:
     """Resolve the common target resolution for every band and partition.
 
+    Angular units are canonical: partitions may sit on different pixel scales,
+    so a resolution in pixels is only meaningful once paired with a grid. The
+    caller divides by whichever cell size it is about to work on.
+
     Args:
-        psfparsn: (nband, ncorr, 3) native resolutions in pixels and radians.
+        psfparsn: (nband, ncorr, 3) native resolutions, axes in the same units
+            as cell_deg implies and the angle in radians.
         psf_pars: Requested (emaj, emin, pa) in degrees, or None to derive it.
         circ_psf: Force a circular beam.
         dilate: Safety factor applied when the target is derived.
-        cell_deg: Cell size in degrees.
+        cell_deg: Cell size that psfparsn's axes are expressed in, so 1.0 when
+            they are already in degrees.
 
     Returns:
-        (ncorr, 3) target resolution in pixels, pixels, radians.
+        (ncorr, 3) target resolution in the same axis units as psfparsn, with
+        the angle in radians.
 
     Raises:
         ValueError: If the requested target is finer than any input resolution.
@@ -223,15 +237,65 @@ def _time_out(hdr) -> float:
     return float(Time(hdr["DATE-OBS"]).unix)
 
 
-def _read_band(paths: list[str], bandid: int, chan: int) -> np.ndarray:
-    """Return one band's (ncorr, ny, nx) plane from a partition's files."""
+def _locate_band(paths: list[str], chan: int) -> tuple[str, int]:
+    """Map a partition-wide channel index onto (file, plane within that file).
+
+    ``chan`` counts in the same traversal order ``frequencies_of`` uses.
+
+    Args:
+        paths: The partition's file paths, in order.
+        chan: Channel index within the partition.
+
+    Returns:
+        The owning path and the plane's index inside that file.
+
+    Raises:
+        ValueError: If the index runs past the end of the partition.
+    """
     remaining = chan
     for path in paths:
-        cube, _ = load_cube(path, dtype=np.float64)
-        if remaining < cube.shape[0]:
-            return cube[remaining]
-        remaining -= cube.shape[0]
-    raise ValueError(f"band {bandid} channel {chan} not found in {paths}")
+        hdr = fits.getheader(path)
+        nplane = int(hdr.get(f"NAXIS{freq_axis_of(hdr)}", 1))
+        if remaining < nplane:
+            return path, remaining
+        remaining -= nplane
+    raise ValueError(f"channel {chan} not found in {paths}")
+
+
+def _read_band(paths: list[str], bandid: int, chan: int) -> np.ndarray:
+    """Return one band's (ncorr, ny, nx) plane from a partition's files."""
+    path, plane = _locate_band(paths, chan)
+    cube, _ = load_cube(path, dtype=np.float64)
+    return cube[plane]
+
+
+def psfparsn_deg(paths: list[str], mapping: dict[int, int], ncorr: int) -> dict[int, np.ndarray]:
+    """Read each band's native resolution from the file that supplies it.
+
+    Reading the whole partition's beams from its first header is wrong for the
+    common split-per-channel layout, where every file carries a single scalar
+    BMAJ describing only its own plane, and for any partition whose files differ in
+    resolution.
+
+    Args:
+        paths: The partition's file paths, in order.
+        mapping: bandid to channel index, for this partition.
+        ncorr: Number of correlations.
+
+    Returns:
+        bandid to an (ncorr, 3) array of (emaj, emin, pa) in degrees, degrees
+        and radians.
+    """
+    out: dict[int, np.ndarray] = {}
+    for bandid, chan in mapping.items():
+        path, plane = _locate_band(paths, chan)
+        hdr = fits.getheader(path)
+        nplane = int(hdr.get(f"NAXIS{freq_axis_of(hdr)}", 1))
+        # cell_deg=1.0 keeps the axes in degrees; the caller converts to the
+        # pixel scale of whichever grid it is about to work on
+        pars = psfpars_from_header(hdr, nplane, ncorr, cell_deg=1.0)
+        out[bandid] = pars[plane]
+    return out
 
 
 def init(
@@ -285,25 +349,34 @@ def init(
     dec = np.deg2rad(float(target_wcs.wcs.crval[1]))
     log.info("Union grid is %d by %d pixels over %d partitions", ny, nx, len(groups))
 
-    residual_groups = group_partitions(residual) if residual else None
-    if residual_groups is not None and len(residual_groups) != len(groups):
-        raise ValueError(
-            f"{len(groups)} image partitions but {len(residual_groups)} residual partitions; "
-            "they must describe the same pointings"
-        )
+    # match residuals to images by partition identity, never by list position:
+    # two equal-sized sets with a swapped pointing would otherwise pair silently
+    residual_by_key = None
+    if residual:
+        residual_by_key = dict(group_partitions(residual))
+        missing = [key for key, _ in groups if key not in residual_by_key]
+        if missing:
+            raise ValueError(
+                f"{len(missing)} image partition(s) have no residual at the same phase centre and grid; "
+                "every --images pointing needs a matching --residual pointing"
+            )
 
     freqs_per_partition = [frequencies_of(paths) for _, paths in groups]
     nominal, mapping = assign_bands(freqs_per_partition, freq_tol)
     nband = nominal.size
 
-    psfparsn = [psfpars_from_header(hdr, nband, ncorr, cell_deg) for hdr in headers]
-    target = resolve_target(np.concatenate(psfparsn, axis=0), psf_pars, circ_psf, dilate, cell_deg)
+    # native resolutions in degrees, read from the file that supplies each band
+    psfparsn = [psfparsn_deg(paths, mapping[pid], ncorr) for pid, (_, paths) in enumerate(groups)]
+    all_native = np.stack([pars for per_part in psfparsn for pars in per_part.values()])
+    target_deg = resolve_target(all_native, psf_pars, circ_psf, dilate)
     log.info(
         "Target resolution %.3e deg by %.3e deg at %.3e deg",
-        target[0, 0] * cell_deg,
-        target[0, 1] * cell_deg,
-        np.rad2deg(target[0, 2]),
+        target_deg[0, 0],
+        target_deg[0, 1],
+        np.rad2deg(target_deg[0, 2]),
     )
+    # stored on the union grid, so PSFPARSF is in union-grid pixels
+    target = target_deg / np.array([cell_deg, cell_deg, 1.0])
 
     url = store_name(output_filename, product)
     Path(url).parent.mkdir(parents=True, exist_ok=True)
@@ -326,9 +399,13 @@ def init(
 
     for pid, (_, paths) in enumerate(groups):
         hdr = headers[pid]
+        # the convolution happens on this partition's native grid, so the
+        # resolutions must be in ITS pixels, not the union grid's
+        part_cell_deg = abs(float(hdr["CDELT1"]))
+        target_pix = target_deg / np.array([part_cell_deg, part_cell_deg, 1.0])
         part_wcs = WCS(hdr).celestial
         part_shape = (int(hdr["NAXIS2"]), int(hdr["NAXIS1"]))
-        res_paths = residual_groups[pid][1] if residual_groups else None
+        res_paths = residual_by_key[groups[pid][0]] if residual_by_key else None
         rhdr = fits.getheader(res_paths[0]) if res_paths else hdr
         band_ids = sorted(mapping[pid])
         band_freqs = np.array([freqs_per_partition[pid][mapping[pid][b]] for b in band_ids], dtype=float)
@@ -352,8 +429,8 @@ def init(
                 model,
                 resid,
                 beam,
-                target,
-                gausspari=psfparsn[pid][bandid],
+                target_pix,
+                gausspari=psfparsn[pid][bandid] / np.array([part_cell_deg, part_cell_deg, 1.0]),
                 products=letters,
                 pb_min=pb_min,
                 nthreads=nthreads,
@@ -391,7 +468,7 @@ def init(
                     "ra0": ra0,
                     "dec0": dec0,
                     "freq_out": float(nominal[bandid]),
-                    "psfparsn": psfparsn[pid][bandid].tolist(),
+                    "psfparsn": (psfparsn[pid][bandid] / np.array([cell_deg, cell_deg, 1.0])).tolist(),
                     "beam_includes_n": False,
                 },
                 coords,

--- a/src/spimple/core/init.py
+++ b/src/spimple/core/init.py
@@ -6,16 +6,34 @@ there is more than one, reprojected onto a union grid. See
 ``docs/wiki/datatree-contract.md``.
 """
 
+import multiprocessing
 import os
 import re
+from pathlib import Path
 
 import numpy as np
 from astropy.io import fits
+from astropy.time import Time
 
-from spimple.utils.datatree import partition_node_name
-from spimple.utils.fits import data_from_header, freq_axis_of
+from spimple.utils.datatree import (
+    PRODUCT_VARS,
+    band_node_name,
+    create_store,
+    partition_node_name,
+    psfpars_from_header,
+    write_node,
+)
+from spimple.utils.fits import data_from_header, expand_image_patterns, freq_axis_of, load_cube
+from spimple.utils.logging import get_logger, log_options
+from spimple.utils.render import dt2fits
+from spimple.utils.restoration import restore_products
+
+log = get_logger("INIT")
 
 PartitionKey = tuple[float, float, float, float, int, int]
+
+BPAR = ["BMAJ", "BMIN", "BPA"]
+_STOKES = {1: "I", 2: "Q", 3: "U", 4: "V", -1: "RR", -2: "LL", -5: "XX", -6: "YY"}
 
 # a thousandth of a pixel, so floating-point noise in a header never splits a partition
 _CELL_FRACTION = 1e-3
@@ -135,3 +153,251 @@ def field_name_for(paths: list[str], pid: int) -> str:
     # or a field genuinely named "deep2" would lose its 2.
     prefix = re.sub(r"[-_.]\d*$", "", prefix).rstrip("-_. ")
     return prefix if prefix else partition_node_name(pid)
+
+
+def stokes_labels(hdr) -> list[str]:
+    """Return the correlation labels named by the FITS STOKES axis.
+
+    Args:
+        hdr: FITS header.
+
+    Returns:
+        One label per plane of the non-frequency, non-celestial axis.
+    """
+    axis = 3 if freq_axis_of(hdr) == 4 else 4
+    ncorr = int(hdr.get(f"NAXIS{axis}", 1))
+    crval = float(hdr.get(f"CRVAL{axis}", 1.0))
+    cdelt = float(hdr.get(f"CDELT{axis}", 1.0))
+    return [_STOKES.get(int(round(crval + i * cdelt)), f"C{i}") for i in range(ncorr)]
+
+
+def store_name(output_filename: str, product: str) -> str:
+    """Return the store path, mirroring pfb's <basename>_<PRODUCT>.dt naming."""
+    return f"{output_filename}_{product.upper()}.dt"
+
+
+def resolve_target(psfparsn, psf_pars, circ_psf: bool, dilate: float, cell_deg: float) -> np.ndarray:
+    """Resolve the common target resolution for every band and partition.
+
+    Args:
+        psfparsn: (nband, ncorr, 3) native resolutions in pixels and radians.
+        psf_pars: Requested (emaj, emin, pa) in degrees, or None to derive it.
+        circ_psf: Force a circular beam.
+        dilate: Safety factor applied when the target is derived.
+        cell_deg: Cell size in degrees.
+
+    Returns:
+        (ncorr, 3) target resolution in pixels, pixels, radians.
+
+    Raises:
+        ValueError: If the requested target is finer than any input resolution.
+    """
+    psfparsn = np.asarray(psfparsn, dtype=float)
+    if psf_pars is None:
+        target = np.empty(psfparsn.shape[1:], dtype=float)
+        target[:, 0] = np.nanmax(psfparsn[:, :, 0], axis=0) * dilate
+        target[:, 1] = np.nanmax(psfparsn[:, :, 1], axis=0) * dilate
+        target[:, 2] = np.nanmean(psfparsn[:, :, 2], axis=0)
+    else:
+        one = np.array([psf_pars[0] / cell_deg, psf_pars[1] / cell_deg, np.deg2rad(psf_pars[2])])
+        target = np.tile(one, (psfparsn.shape[1], 1))
+        if np.any(psfparsn[:, :, 0] > target[None, :, 0]) or np.any(psfparsn[:, :, 1] > target[None, :, 1]):
+            raise ValueError(
+                "the requested resolution is finer than an input resolution; convolution can only degrade resolution"
+            )
+    if circ_psf:
+        axis = np.maximum(target[:, 0], target[:, 1])
+        target[:, 0] = axis
+        target[:, 1] = axis
+        target[:, 2] = 0.0
+    return target
+
+
+def _time_out(hdr) -> float:
+    """Return DATE-OBS as unix seconds, or 0.0 when the header has no epoch."""
+    if "DATE-OBS" not in hdr:
+        return 0.0
+    return float(Time(hdr["DATE-OBS"]).unix)
+
+
+def _read_band(paths: list[str], bandid: int, chan: int) -> np.ndarray:
+    """Return one band's (ncorr, ny, nx) plane from a partition's files."""
+    remaining = chan
+    for path in paths:
+        cube, _ = load_cube(path, dtype=np.float64)
+        if remaining < cube.shape[0]:
+            return cube[remaining]
+        remaining -= cube.shape[0]
+    raise ValueError(f"band {bandid} channel {chan} not found in {paths}")
+
+
+def init(
+    images: list[str],
+    output_filename: str,
+    residual: list[str] | None = None,
+    psf_pars: tuple[float, float, float] | None = None,
+    circ_psf: bool = False,
+    dilate: float = 1.05,
+    beam_model: str | None = None,
+    band: str = "L",
+    pb_min: float = 0.15,
+    padding_frac: float = 0.5,
+    products: str = "aik",
+    channel_weights_keyword: str = "WSCVWSUM",
+    freq_tol: float | None = None,
+    fits_outputs: str = "",
+    fits_output_folder: str | None = None,
+    overwrite: bool = False,
+    out_dtype: str = "f4",
+    nthreads: int | None = None,
+    nworkers: int = 1,
+):
+    """
+    Ingest FITS images into a pfb-imaging style datatree.
+
+    Input files are grouped into partitions by phase centre and grid and into
+    bands by frequency, homogenised to a common resolution, and written to a
+    zarr store that spifit and mosaic consume. A single pointing needs no
+    mosaic step because init populates the band nodes itself.
+    """
+    log_options(log, **locals())
+
+    images = expand_image_patterns(images)
+    residual = expand_image_patterns(residual) if residual else None
+    if not nthreads:
+        nthreads = multiprocessing.cpu_count()
+
+    groups = group_partitions(images)
+    if len(groups) > 1:
+        raise NotImplementedError(f"{len(groups)} partitions found; multi-pointing ingest is not implemented yet")
+    if beam_model is not None:
+        raise NotImplementedError("beam models are not implemented yet; run without beam-model")
+
+    part_paths = groups[0][1]
+    hdr = fits.getheader(part_paths[0])
+    corr = stokes_labels(hdr)
+    ncorr = len(corr)
+    cell_deg = abs(float(hdr["CDELT1"]))
+    cell_rad = np.deg2rad(cell_deg)
+    ny, nx = int(hdr["NAXIS2"]), int(hdr["NAXIS1"])
+    product = "".join(corr)
+
+    nominal, mapping = assign_bands([frequencies_of(part_paths)], freq_tol)
+    nband = nominal.size
+
+    psfparsn = psfpars_from_header(hdr, nband, ncorr, cell_deg)
+    target = resolve_target(psfparsn, psf_pars, circ_psf, dilate, cell_deg)
+    log.info(
+        "Target resolution %.3e deg by %.3e deg at %.3e deg",
+        target[0, 0] * cell_deg,
+        target[0, 1] * cell_deg,
+        np.rad2deg(target[0, 2]),
+    )
+
+    url = store_name(output_filename, product)
+    Path(url).parent.mkdir(parents=True, exist_ok=True)
+    create_store(
+        url,
+        {
+            "product": product,
+            "nband": int(nband),
+            "ntime": 1,
+            "nx": nx,
+            "ny": ny,
+            "cell_rad": cell_rad,
+            "origin": "spimple-init",
+        },
+        overwrite=overwrite,
+    )
+
+    beam = np.ones((ncorr, ny, nx), dtype=np.float64)
+    rhdr = fits.getheader(residual[0]) if residual else hdr
+    time_out = _time_out(hdr)
+    ra, dec = np.deg2rad(float(hdr["CRVAL1"])), np.deg2rad(float(hdr["CRVAL2"]))
+    letters = tuple(k for k in ("a", "i", "k") if k in products)
+
+    for bandid in range(nband):
+        chan = mapping[0].get(bandid)
+        if chan is None:
+            continue
+        model = _read_band(part_paths, bandid, chan)
+        if residual:
+            resid = _read_band(residual, bandid, chan)
+        else:
+            # no residual: the input is a restored image, so it carries the
+            # resolution and there is no separate model to convolve
+            resid = model
+            model = np.zeros_like(resid)
+
+        out = restore_products(
+            model,
+            resid,
+            beam,
+            target,
+            gausspari=psfparsn[bandid],
+            products=letters,
+            pb_min=pb_min,
+            nthreads=nthreads,
+            padding_frac=padding_frac,
+        )
+
+        rms = np.array([float(np.std(resid[c])) for c in range(ncorr)])
+        if channel_weights_keyword in rhdr:
+            wsum = np.full(ncorr, float(rhdr[channel_weights_keyword]))
+        else:
+            wsum = np.where(rms > 0, 1.0 / np.maximum(rms, 1e-30) ** 2, 1.0)
+
+        data_vars = {PRODUCT_VARS[k]: (("corr", "y", "x"), out[k].astype(out_dtype)) for k in letters}
+        data_vars["BEAM"] = (("corr", "y", "x"), beam.astype(out_dtype))
+        data_vars["WSUM"] = (("corr",), wsum.astype(np.float64))
+        data_vars["RMS"] = (("corr",), rms.astype(np.float64))
+        data_vars["PSFPARSF"] = (("corr", "bpar"), target.astype(np.float64))
+        attrs = {
+            "bandid": int(bandid),
+            "timeid": 0,
+            "freq_out": float(nominal[bandid]),
+            "freq_nominal": float(nominal[bandid]),
+            "time_out": time_out,
+            "ra": ra,
+            "dec": dec,
+            "cell_rad": cell_rad,
+            "l0": 0.0,
+            "m0": 0.0,
+            "pb_min": float(pb_min),
+        }
+        coords = {"corr": corr, "bpar": BPAR}
+        node = band_node_name(bandid, 0)
+        # one partition: the band product IS the partition product, so write both
+        write_node(
+            url,
+            f"{node}/{partition_node_name(0)}",
+            {**data_vars, "MASK": (("corr", "y", "x"), np.ones((ncorr, ny, nx), dtype=bool))},
+            {
+                "field_name": field_name_for(part_paths, 0),
+                "ra0": ra,
+                "dec0": dec,
+                "freq_out": float(nominal[bandid]),
+                "psfparsn": psfparsn[bandid].tolist(),
+                "beam_includes_n": False,
+            },
+            coords,
+        )
+        write_node(url, node, data_vars, attrs, coords)
+        log.info("Wrote band %d at %.4e Hz", bandid, nominal[bandid])
+
+    if fits_outputs:
+        folder = fits_output_folder or str(Path(url).parent / "fits")
+        Path(folder).mkdir(parents=True, exist_ok=True)
+        oname = f"{folder}/{Path(output_filename).name}_{product}"
+        for letter in ("a", "i", "k"):
+            if letter.upper() in fits_outputs or letter in fits_outputs:
+                dt2fits(
+                    url,
+                    PRODUCT_VARS[letter],
+                    oname,
+                    otype=out_dtype,
+                    do_mfs=letter in fits_outputs,
+                    do_cube=letter.upper() in fits_outputs,
+                )
+
+    log.info("All done here")

--- a/src/spimple/core/mosaic.py
+++ b/src/spimple/core/mosaic.py
@@ -4,152 +4,113 @@ import multiprocessing
 from pathlib import Path
 
 import numpy as np
-import ray
-from astropy.io import fits
 
-from spimple.utils.fits import expand_image_patterns, set_wcs
+from spimple.utils.datatree import PRODUCT_VARS, band_nodes, open_store, partition_nodes, write_node
 from spimple.utils.logging import get_logger, log_options
-from spimple.utils.mosaic import mosaic_info, project, stitch_images
+from spimple.utils.mosaic import stitch_band
+from spimple.utils.render import dt2fits
 
 log = get_logger("MOSAIC")
 
 
 def mosaic(
-    images: list[str],
-    output_filename: str,
-    beam_model: str | None = None,
-    band: str = "L",
-    ref_image: str | None = None,
-    padding: float = 0.1,
-    method: str = "interp",
-    nthreads: int = 1,
-    nworkers: int = 1,
+    store: str,
+    output_filename: str | None = None,
+    eta: float = 1e-3,
+    products: str = "aik",
+    fits_outputs: str = "I",
+    fits_output_folder: str | None = None,
     out_dtype: str = "f4",
-    convolve: bool = False,
-    redo_project: bool = False,
-    debug: bool = False,
+    nthreads: int | None = None,
+    nworkers: int = 1,
 ):
     """
-    Mosaic multiple FITS images together onto a common coordinate grid.
+    Combine the image space partitions of a datatree into band mean images.
 
-    This function takes multiple FITS images and combines them into a single
-    mosaic image using interpolation to handle different coordinate systems
-    and spatial coverage.
+    Only meaningful for a store written by spimple init from more than one
+    pointing. A tree from pfb-imaging mosaics in visibility space, so its band
+    nodes arrive already populated and there is nothing here to combine.
     """
     log_options(log, **locals())
 
-    images = expand_image_patterns(images)
-
-    # ray init
     if not nthreads:
-        nthreads = multiprocessing.cpu_count() // 2
+        nthreads = multiprocessing.cpu_count()
 
-    ray.init(
-        num_cpus=nworkers,
-        logging_level="INFO",
-        ignore_reinit_error=True,
-        local_mode=debug,
-    )
+    store = str(store)
+    dt = open_store(store)
+    nodes = band_nodes(dt)
+    if not nodes:
+        raise ValueError(f"{store} has no band nodes")
 
-    path = Path(output_filename)
-    if not path.parent.exists():
-        log.info("Creating output directory: %s", path.parent)
-        path.parent.mkdir(parents=True, exist_ok=True)
+    letters = tuple(k for k in ("a", "i", "k") if k in products)
+    combined = 0
+    for node in nodes:
+        # A pfb tree has partition children too, but they hold visibility-space
+        # arrays and a BEAM -- never the image-space products with a footprint
+        # mask that this command combines. Test for what we consume, not for
+        # the mere presence of a child.
+        parts = [
+            p
+            for p in partition_nodes(dt, node)
+            if "MASK" in dt[f"{node}/{p}"].ds and PRODUCT_VARS["a"] in dt[f"{node}/{p}"].ds
+        ]
+        if not parts:
+            raise ValueError(
+                f"{store}/{node} has no image-space partitions to combine and its band products are "
+                "already populated; a pfb-imaging tree mosaics in visibility space and needs no "
+                "spimple mosaic step"
+            )
+        datasets = [dt[f"{node}/{p}"].ds for p in parts]
 
-    # project images
-    log.info("Generating reference header")
-    # `images` was already resolved by expand_image_patterns above: globs are
-    # expanded, entries de-duplicated and sorted, and a pattern matching nothing
-    # has already raised. Re-globbing here would additionally break on absolute
-    # paths, since Path().glob rejects non-relative patterns.
-    ref_wcs, ufreqs, out_names = mosaic_info(images, output_filename)
+        apparent = np.stack([ds[PRODUCT_VARS["a"]].values for ds in datasets])
+        beams = np.stack([ds.BEAM.values for ds in datasets])
+        masks = np.stack([ds.MASK.values[0] for ds in datasets])
+        mixed = np.stack([ds[PRODUCT_VARS["k"]].values for ds in datasets]) if "k" in letters else None
+        wsums = np.stack([np.atleast_1d(ds.WSUM.values) for ds in datasets])
+        rms = np.stack([np.atleast_1d(ds.RMS.values) for ds in datasets]) if "RMS" in datasets[0] else None
 
-    nyo, nxo = ref_wcs.array_shape
-    nchano = ufreqs.size
-    log.info("Output image will be of shape (%s, %s, %s)", nchano, nxo, nyo)
+        out = stitch_band(apparent, beams, masks, mixed=mixed, rms=rms, wsums=wsums, eta=eta)
 
-    # check if projection has been done
-    do_project = False
-    if not redo_project:
-        for name in out_names:
-            if not Path(name).is_dir():
-                do_project = True
-                break
-    else:
-        do_project = True
+        ref = dt[node].ds
+        data_vars = {
+            "IMAGE": (("corr", "y", "x"), out["IMAGE"].astype(out_dtype)),
+            "BIMAGE": (("corr", "y", "x"), out["BIMAGE"].astype(out_dtype)),
+            "BEAM": (("corr", "y", "x"), out["BEAM"].astype(out_dtype)),
+            "SPATIALWGT": (("corr", "y", "x"), out["SPATIALWGT"].astype(out_dtype)),
+            "WSUM": (("corr",), out["WSUM"].astype(np.float64)),
+            "PSFPARSF": (("corr", "bpar"), ref.PSFPARSF.values),
+        }
+        if "KIMAGE" in out:
+            data_vars["KIMAGE"] = (("corr", "y", "x"), out["KIMAGE"].astype(out_dtype))
+        if "RMS" in out:
+            data_vars["RMS"] = (("corr",), out["RMS"].astype(np.float64))
 
-    if do_project:
-        log.info("Projecting images onto common wcs")
-        tasks = []
-        for imnum, im in enumerate(images):
-            fut = project.remote(im, imnum, ref_wcs, beam_model, output_filename)
-            tasks.append(fut)
+        write_node(
+            store,
+            node,
+            data_vars,
+            {"eta": float(eta), "nparts": len(parts)},
+            {"corr": list(ref.corr.values), "bpar": list(ref.bpar.values)},
+        )
+        combined += 1
+        log.info("Combined %d partitions for %s", len(parts), node)
 
-        # Process tasks as they complete
-        remaining_tasks = tasks.copy()
-        while remaining_tasks:
-            # Wait for at least 1 task to complete
-            ready, remaining_tasks = ray.wait(remaining_tasks, num_returns=1)
+    log.info("Combined %d bands", combined)
 
-            # Process the completed task
-            for task in ready:
-                result = ray.get(task)
-                log.info("Completed: %s", result)
-
-    log.info("Solving linear system")
-    outim = np.zeros((nchano, nxo, nyo))
-    outwgt = np.zeros((nchano, nxo, nyo))
-    tasks = []
-    for freq in ufreqs:
-        fut = stitch_images.remote(freq, out_names)
-        tasks.append(fut)
-
-    # Process tasks as they complete
-    remaining_tasks = tasks.copy()
-    while remaining_tasks:
-        # Wait for at least 1 task to complete
-        ready, remaining_tasks = ray.wait(remaining_tasks, num_returns=1)
-
-        # Process the completed task
-        for task in ready:
-            image, weight, info, freq = ray.get(task)
-            log.info("Conjugate gradient completed after %s iterations for freq = %s", info, freq)
-            c = np.nonzero(ufreqs == freq)[0]
-            outim[c] = image
-            outwgt[c] = weight
-
-    # Create output header
-    cell_x = np.abs(ref_wcs.wcs.cdelt[0])
-    cell_y = np.abs(ref_wcs.wcs.cdelt[1])
-    ra = ref_wcs.wcs.crval[0] * np.pi / 180
-    dec = ref_wcs.wcs.crval[1] * np.pi / 180
-    out_hdr = set_wcs(
-        cell_x,
-        cell_y,
-        nxo,
-        nyo,
-        (ra, dec),
-        ufreqs,
-        unit="Jy/beam",
-        gausspar=None,
-        ms_time=None,
-        header=True,
-        casambm=False,
-    )
-
-    # Save output
-
-    hdu = fits.PrimaryHDU(header=out_hdr)
-    hdu.data = outim
-    hdu.writeto(output_filename, overwrite=True)
-    log.info("Saved mosaic to %s", output_filename)
-
-    # Save weight map
-    weight_filename = output_filename.replace(".fits", "_weights.fits")
-    hdu.data = outwgt
-    hdu.writeto(weight_filename, overwrite=True)
-    log.info("Saved weight map to %s", weight_filename)
+    if fits_outputs:
+        base = output_filename or str(Path(store).with_suffix(""))
+        folder = fits_output_folder or str(Path(store).parent / "fits")
+        Path(folder).mkdir(parents=True, exist_ok=True)
+        oname = f"{folder}/{Path(base).name}"
+        for letter in ("a", "i", "k"):
+            if letter in fits_outputs or letter.upper() in fits_outputs:
+                dt2fits(
+                    store,
+                    PRODUCT_VARS[letter],
+                    oname,
+                    otype=out_dtype,
+                    do_mfs=letter in fits_outputs,
+                    do_cube=letter.upper() in fits_outputs,
+                )
 
     log.info("Mosaic completed successfully")
-
-    ray.shutdown()

--- a/src/spimple/core/mosaic.py
+++ b/src/spimple/core/mosaic.py
@@ -131,7 +131,7 @@ def mosaic(
         (ra, dec),
         ufreqs,
         unit="Jy/beam",
-        GuassPar=None,
+        gausspar=None,
         ms_time=None,
         header=True,
         casambm=False,

--- a/src/spimple/core/spifit.py
+++ b/src/spimple/core/spifit.py
@@ -2,487 +2,218 @@
 
 import multiprocessing
 
-import dask.array as da
 import numpy as np
-from africanus.model.spi.dask import fit_spi_components
-from astropy.io import fits
-from katbeam import JimBeam
 
-from spimple.utils.beam import interpolate_beam
-from spimple.utils.convolution import convolve2gaussres
-from spimple.utils.fits import data_from_header, expand_image_patterns, load_fits, save_fits, set_header_info
+from spimple.utils.datatree import (
+    PRODUCT_VARS,
+    band_nodes,
+    check_homogeneous,
+    open_store,
+    partition_nodes,
+    timeids,
+)
+from spimple.utils.fits import save_fits, set_wcs
 from spimple.utils.logging import get_logger, log_options
 
 log = get_logger("SPIFIT")
 
+_SCALES = {"apparent": "a", "intrinsic": "i", "mixed": "k"}
+
 
 def spifit(
-    images: list[str],
+    store: str,
     output_filename: str,
-    residual: list[str] | None = None,
-    psf_pars: tuple[float, float, float] | None = None,
-    circ_psf: bool = False,
-    threshold: float = 10,
-    max_dr: float = 1000,
-    nthreads: int | None = None,
+    flux_scale: str = "apparent",
+    products: str = "aeikId",
+    threshold: float = 10.0,
+    max_dr: float = 1000.0,
     pb_min: float = 0.15,
-    products: str = "aeikIcmrbd",
-    padding_frac: float = 0.5,
-    dont_convolve: bool = False,
-    channel_weights_keyword: str = "WSCIMWG",
-    channel_freqs: list[float] | None = None,
-    ref_freq: float | None = None,
-    out_dtype: str = "f4",
-    add_convolved_residuals: bool = False,
-    ms: list[str] | None = None,
-    beam_model: str | None = None,
-    sparsify_time: int = 10,
-    corr_type: str = "linear",
-    band: str = "L",
     deselect_bands: list[int] | None = None,
+    ref_freq: float | None = None,
+    timeid: int | None = None,
+    out_dtype: str = "f4",
+    nthreads: int | None = None,
 ):
     """
-    Runs spectral index fitting on radio astronomy image cubes.
+    Fit a spectral index model to the band images of a datatree.
 
-    This function orchestrates the workflow for fitting spectral index (alpha) and
-    reference intensity (I0) maps from multi-frequency radio interferometric image
-    cubes. It handles model and residual image loading, PSF and beam parameter
-    extraction, optional convolution, masking, thresholding, frequency band selection,
-    component extraction, spectral fitting, and output of results as FITS files.
-    The tool supports various options for beam modeling, channel weighting, and output
-    product selection, and is designed for efficient processing of large datasets using
-    Dask for parallelization.
+    The tree must already be homogenised to a single resolution, by spimple init
+    or by pfb restore with a target resolution. Multi partition trees written by
+    spimple init must be combined with spimple mosaic first.
     """
     log_options(log, **locals())
 
-    images = expand_image_patterns(images)
-    if residual is not None:
-        residual = expand_image_patterns(residual)
+    import dask.array as da
+    from africanus.model.spi.dask import fit_spi_components
 
     if not nthreads:
         nthreads = multiprocessing.cpu_count()
+    if flux_scale not in _SCALES:
+        raise ValueError(f"Unknown flux-scale {flux_scale}, expected one of {sorted(_SCALES)}")
+    column = PRODUCT_VARS[_SCALES[flux_scale]]
 
-    if psf_pars is None:
-        log.info("Attempting to take psf_pars from residual/image fits header")
-        try:
-            rhdr = fits.getheader(residual[0])
-        except Exception:
-            rhdr = fits.getheader(images[0])
+    store = str(store)
+    output_filename = str(output_filename)
+    dt = open_store(store)
+    wanted = timeids(dt) if timeid is None else [timeid]
+    if not wanted:
+        raise ValueError(f"{store} has no band nodes")
 
-        if "BMAJ1" in rhdr:
-            emaj = rhdr["BMAJ1"]
-            emin = rhdr["BMIN1"]
-            pa = rhdr["BPA1"]
-            gaussparf = (emaj, emin, pa)
-        elif "BMAJ" in rhdr:
-            emaj = rhdr["BMAJ"]
-            emin = rhdr["BMIN"]
-            pa = rhdr["BPA"]
-            gaussparf = (emaj, emin, pa)
-        else:
-            raise ValueError("No beam parameters found in residual.You will have to provide them manually.")
+    for tid in wanted:
+        nodes = band_nodes(dt, timeid=tid)
+        dropped = set(deselect_bands or ())
+        keep = [n for n in nodes if int(dt[n].ds.attrs["bandid"]) not in dropped]
+        if dropped:
+            log.info("Dropping bands %s", sorted(dropped))
 
-    else:
-        gaussparf = tuple(psf_pars)
-
-    if circ_psf:
-        e = np.maximum(gaussparf[0], gaussparf[1])
-        gaussparf_list = list(gaussparf)
-        gaussparf_list[0] = e
-        gaussparf_list[1] = e
-        gaussparf_list[2] = 0.0
-        gaussparf = tuple(gaussparf_list)
-
-    emaj = gaussparf[0]
-    emin = gaussparf[1]
-    pa = gaussparf[2]
-    log.info("Using emaj = %3.2e, emin = %3.2e, PA = %3.2e", emaj, emin, pa)
-
-    # load model images or cube
-    model_header = {}
-    for i, m in enumerate(images):
-        model = load_fits(m, dtype=out_dtype).squeeze()
-        orig_shape = model.shape
-        mhdr = fits.getheader(m)
-        model_header[i] = [model, mhdr]
-
-    l_coord, ref_l = data_from_header(mhdr, axis=1)
-    l_coord -= ref_l
-    m_coord, ref_m = data_from_header(mhdr, axis=2)
-    m_coord -= ref_m
-
-    if mhdr["CTYPE4"].lower() in ["freq", "speclnmf"]:
-        freq_axis = 4
-        stokes_axis = 3
-    elif mhdr["CTYPE3"].lower() in ["freq", "speclnmf"]:
-        freq_axis = 3
-        stokes_axis = 4
-    else:
-        raise ValueError("Freq axis must be 3rd or 4th")
-
-    mfs_shape = list(orig_shape)
-    mfs_shape[0] = 1
-    mfs_shape = tuple(mfs_shape)
-
-    # Fixed: Separate list and array variables to help mypy type inference
-    # generate model frequencies and model slices
-    # incase one/more than one frequency models are provided
-    freq_list: list[float] = []
-    models_data = []
-    for model_data, model_hdr in model_header.values():
-        mhdr = model_hdr
-        freq, ref_freq = data_from_header(mhdr, axis=freq_axis)
-        freq_list.extend(freq)
-        # for 3d (cubes) image seperate individual frequency model
-        # to stack later with the rest
-        if len(model_data.shape) > 2:
-            models_data.extend(list(model_data))
-        else:
-            models_data.append(model_data)
-    # stack model data cube
-    model = np.stack(models_data)
-    # Create numpy array with proper type annotation
-    freqs = np.array(channel_freqs) if channel_freqs is not None else np.array(freq_list)
-    nband = freqs.size
-    if nband < 2:
-        raise ValueError("Can't produce alpha map from a single band image")
-    npix_l = l_coord.size
-    npix_m = m_coord.size
-
-    # update cube psf-pars
-    for i in range(1, nband + 1):
-        mhdr["BMAJ" + str(i)] = gaussparf[0]
-        mhdr["BMIN" + str(i)] = gaussparf[1]
-        mhdr["BPA" + str(i)] = gaussparf[2]
-
-    ref_freq_param = ref_freq  # Store parameter value
-    if ref_freq_param is not None and ref_freq_param != ref_freq:
-        ref_freq = ref_freq_param
-        log.info("Provided reference frequency does not match that of fits file. Will overwrite.")
-
-    log.info("Cube frequencies:")
-    with np.printoptions(precision=2):
-        log.info("%s", freqs)
-    log.info("Reference frequency is %3.2e Hz", ref_freq)
-
-    # LB - new header for cubes if ref_freqs differ
-    new_hdr = set_header_info(mhdr, ref_freq, freq_axis, beampars=gaussparf)
-
-    # save next to model if no outfile is provided
-    outfile = output_filename
-
-    xx, yy = np.meshgrid(l_coord, m_coord, indexing="ij")
-    # load beam
-    if beam_model is not None:
-        # we can pass in either a fits file with the already interpolated
-        # beam or we can interpolate from scratch
-        if beam_model.endswith(".fits"):
-            bhdr = fits.getheader(beam_model)
-            l_coord_beam, ref_lb = data_from_header(bhdr, axis=1)
-            l_coord_beam -= ref_lb
-            if not np.array_equal(l_coord_beam, l_coord):
-                raise ValueError(
-                    "l coordinates of beam model do not match those of image. "
-                    "Use power_beam_maker to interpolate to fits header."
+        for node in keep:
+            if column not in dt[node].ds:
+                hint = (
+                    "run spimple mosaic to combine its partitions"
+                    if partition_nodes(dt, node)
+                    else "the tree carries no such product"
                 )
+                raise ValueError(f"{node} has no {column}; {hint}")
+        datasets = [dt[n].ds for n in keep]
+        if len(datasets) < 2:
+            raise ValueError("Can't produce alpha map from a single band image")
 
-            m_coord_beam, ref_mb = data_from_header(bhdr, axis=2)
-            m_coord_beam -= ref_mb
-            if not np.array_equal(m_coord_beam, m_coord):
-                raise ValueError(
-                    "m coordinates of beam model do not match those of image. "
-                    "Use power_beam_maker to interpolate to fits header."
+        psfparsf = check_homogeneous(datasets)
+        log.info("Fitting at a resolution of %s pixels", psfparsf[0])
+
+        for node in keep:
+            if any(dt[f"{node}/{p}"].ds.attrs.get("beam_includes_n") for p in partition_nodes(dt, node)):
+                log.warning(
+                    "BEAM in this tree is B/n, not the bare primary beam (beam_includes_n is set). "
+                    "The fitted flux is biased by n, about 0.2 percent at a 5 degree field edge. "
+                    "Correct with B = BEAM * n; see docs/wiki/design-decisions.md"
                 )
+                break
 
-            freqs_beam, _ = data_from_header(bhdr, axis=freq_axis)
-            if not np.array_equal(freqs, freqs_beam):
-                raise ValueError(
-                    "Freqs of beam model do not match those of image. "
-                    "Use power_beam_maker to interpolate to fits header."
-                )
+        cube = np.stack([ds[column].values for ds in datasets])  # (nband, ncorr, ny, nx)
+        beam = np.stack([ds.BEAM.values for ds in datasets])
+        wsums = np.stack([np.atleast_1d(ds.WSUM.values) for ds in datasets])
+        freqs = np.array([float(ds.attrs["freq_out"]) for ds in datasets])
+        nband, ncorr, ny, nx = cube.shape
+        ref = datasets[0]
+        cell_deg = np.rad2deg(float(ref.attrs["cell_rad"]))
 
-            beam_image = load_fits(beam_model, dtype=out_dtype).squeeze()
-        elif beam_model == "JimBeam":
-            beam_image = []
-            if band.lower() == "l":
-                beam = JimBeam("MKAT-AA-L-JIM-2020")
-            elif band.lower() == "uhf":
-                beam = JimBeam("MKAT-AA-UHF-JIM-2020")
-            elif band.lower() == "s":
-                beam = JimBeam("MKAT-AA-S-JIM-2020")
-            else:
-                raise ValueError(f"Unknown beam model for katbeam in band {band}")
-            beam_image = np.zeros_like(model)
-            for v in range(freqs.size):
-                beam_image[v] = beam.I(xx, yy, freqs[v] / 1e6)  # freqs in MHz
+        # a local, so a second timeid does not inherit the first one's default
+        nu_ref = ref_freq if ref_freq is not None else float(np.sum(freqs * wsums[:, 0]) / np.sum(wsums[:, 0]))
+        log.info("Reference frequency is %3.2e Hz", nu_ref)
 
-        else:
-            # field=0: spifit has no --field option; extract_dde_info previously read
-            # opts.field off a BeamOpts that never set it, raising AttributeError.
-            beam_image = interpolate_beam(
-                xx,
-                yy,
-                freqs,
-                beam_model=beam_model,
-                ms=ms,
-                field=0,
-                sparsify_time=sparsify_time,
-                corr_type=corr_type,
-                nthreads=nthreads,
-            )
-
-        if "b" in products:
-            name = outfile + ".power_beam.fits"
-            save_fits(
-                name,
-                np.expand_dims(beam_image, axis=4 - stokes_axis),
-                mhdr,
-                dtype=out_dtype,
-            )
-            log.info("Wrote average power beam to %s", name)
-
-    else:
-        beam_image = np.ones(model.shape, dtype=out_dtype)
-
-    # beam cut off
-    model = np.where(beam_image > pb_min, model, 0.0)
-
-    if not dont_convolve:
-        log.info("Convolving model")
-        # convolve model to desired resolution
-        model, gausskern = convolve2gaussres(model, xx, yy, gaussparf, nthreads, None, padding_frac)
-
-        # save clean beam
-        if "c" in products:
-            name = outfile + ".clean_psf.fits"
-            save_fits(name, gausskern, new_hdr, dtype=out_dtype)
-            log.info("Wrote clean psf to %s", name)
-
-        # save convolved model
-        if "m" in products:
-            name = outfile + ".convolved_model.fits"
-            save_fits(name, model, new_hdr, dtype=out_dtype)
-            log.info("Wrote convolved model to %s", name)
-
-    # add in residuals and set threshold
-    if residual:
-        # get headers and frequencies from residual image(s)
-        residuals = [load_fits(res, dtype=out_dtype) for res in residual]
-        resid = np.stack(residuals).squeeze()
-        rhdr = [fits.getheader(res) for res in residual]
-        freqs_res = np.array([data_from_header(fits.getheader(res), axis=freq_axis)[0] for res in residual]).flatten()
-        freqs_res = freqs if channel_freqs else freqs_res
-        if not np.array_equal(freqs, freqs_res):
-            raise ValueError("Freqs of residual do not match those of model")
-
-        # get l and m coordinate from residual image(s)
-        l_res, ref_lb = data_from_header(rhdr[0], axis=1)
-        l_res -= ref_lb
-        if not np.array_equal(l_res, l_coord):
-            raise ValueError("l coordinates of residual do not match those of model")
-        m_res, ref_mb = data_from_header(rhdr[0], axis=2)
-        m_res -= ref_mb
-        if not np.array_equal(m_res, m_coord):
-            raise ValueError("m coordinates of residual do not match those of model")
-
-        # convolve residual to same resolution as model
-        gausspari = ()
-        # get beam values from individual headers
-        if len(rhdr) > 1:
-            for hdr in rhdr:
-                keys = ["BMAJ", "BMIN", "BPA"]
-                if all(k in hdr for k in keys):
-                    emaj, emin, pa = [hdr[k] for k in keys]
-                    gausspari += (tuple([hdr[k] for k in keys]),)
-        # residual cube provides beam params as BMAJ1, BMAJ2,...
-        else:
-            hdr = rhdr[0]
-            for i in range(1, nband + 1):
-                key = "BMAJ" + str(i)
-                if key in hdr:
-                    emaj = hdr[key]
-                    emin = hdr["BMIN" + str(i)]
-                    pa = hdr["BPA" + str(i)]
-                    gausspari += ((emaj, emin, pa),)
-        if gausspari:
-            log.info("Gausspars in residual header: %s", gausspari)  # type: ignore[unreachable]
-        else:
-            log.info("Can't find Gausspars in residual header, unable to add residuals back in")
-            gausspari = None
-
-        if gausspari is not None and add_convolved_residuals:  # type: ignore[unreachable]
-            log.info("Convolving residuals")  # type: ignore[unreachable]
-            resid, _ = convolve2gaussres(
-                resid,
-                xx,
-                yy,
-                gaussparf,
-                nthreads,
-                gausspari,
-                padding_frac,
-                norm_kernel=False,
-            )
-            model += resid
-            log.info("Convolved residuals added to convolved model")
-
-            if "r" in products:
-                name = outfile + ".convolved_residual.fits"
-                save_fits(name, resid, rhdr[0])
-                log.info("Wrote convolved residuals to %s", name)
-
-        counts = np.sum(resid != 0)
-        rms = np.sqrt(np.sum(resid**2) / counts)
-        rms_cube = np.std(resid.reshape(nband, npix_l * npix_m), axis=1).ravel()
-        threshold_val = threshold * rms
-        log.info("Setting cutoff threshold as %s times the rms of the residual ", threshold)
-        del resid
-    else:
-        log.info(
-            "No residual provided. Setting  threshold i.t.o dynamic range. Max dynamic range is %s",
-            max_dr,
-        )
-        mask = ~np.isnan(model)
-        threshold_val = model[mask].max() / max_dr
-        rms_cube = None
-
-    log.info("Threshold set to %s Jy.", threshold_val)
-
-    # remove completely nan slices
-    freq_mask = np.isnan(model)
-    fidx = ~np.all(freq_mask, axis=(1, 2))
-
-    # exclude any bands that might be awful
-    if deselect_bands:
-        log.info("Deselected bands are: %s", deselect_bands)
-        for bidx in deselect_bands:
-            fidx[bidx] = False
-
-    if fidx.any():
-        model = model[fidx]
-        beam_image = beam_image[fidx]
-        freqs = freqs[fidx]
-        gaussparf = list(gaussparf)
-        new_hdr = set_header_info(mhdr, ref_freq, freq_axis, beampars=tuple(gaussparf))
-
-    # get pixels above threshold
-    minimage = np.amin(model, axis=0)
-    maskindices = np.argwhere(minimage > threshold_val)
-    if not maskindices.size:
-        raise ValueError(
-            "No components found above threshold. "
-            "Try lowering your threshold."
-            f"Max of convolved model is {model.max():3.2e}"
-        )
-    fitcube = model[:, maskindices[:, 0], maskindices[:, 1]].T
-    beam_comps = beam_image[:, maskindices[:, 0], maskindices[:, 1]].T
-
-    # set weights for fit
-    # Note: channel_weights_keyword is not used in the original code, only channel_weights
-    # The original code checked opts.channel_weights but we don't have that parameter
-    # Based on CLI, we should get weights from the header using channel_weights_keyword
-    channel_weights = None  # This would need to be extracted from headers if implemented
-    if channel_weights is not None:
-        weights = np.array(channel_weights)[fidx]
-        try:
-            assert weights.size == nband
-            log.info("Using provided channel weights.")
-        except Exception as e:
-            log.info("Number of provided channel weights not equal to number of imaging bands")
-    else:
-        if residual:
-            log.info("Getting weights from list of image headers.")
-            rhdr = []
-            for res in residual:
-                rhdr.append(fits.getheader(res))
-            weights = np.array([hdr["WSCVWSUM"] for hdr in rhdr])
-            weights /= weights.max()
-        elif rms_cube is not None:
-            log.info("Using RMS in each imaging band to determine weights.")
-            weights = np.where(rms_cube[fidx] > 0, 1.0 / rms_cube[fidx] ** 2, 0.0)
-            # normalise
+        # band weights: WSUM, else 1/RMS^2, else equal
+        if np.all(wsums[:, 0] > 0):
+            weights = wsums[:, 0] / wsums[:, 0].max()
+        elif all("RMS" in ds for ds in datasets):
+            rms = np.array([float(np.atleast_1d(ds.RMS.values)[0]) for ds in datasets])
+            weights = np.where(rms > 0, 1.0 / rms**2, 0.0)
             weights /= weights.max()
         else:
-            log.info("No residual or channel weights provided. Using equal weights.")
-            weights = np.ones(fidx.sum(), dtype=np.float64)
+            weights = np.ones(nband, dtype=np.float64)
         log.info("Channel weights: %s", weights)
 
-    ncomps, _ = fitcube.shape
-    cchunks = np.maximum(1, ncomps // nthreads)
-    fitcube = da.from_array(fitcube.astype(np.float64), chunks=(cchunks, nband))
-    beam_comps = da.from_array(beam_comps.astype(np.float64), chunks=(cchunks, nband))
-    weights = da.from_array(weights.astype(np.float64), chunks=(nband))
-    freqsdask = da.from_array(freqs.astype(np.float64), chunks=(nband))
+        # threshold: the band RMS if the tree carries it, else a normalised
+        # RESIDUAL, else a dynamic range cut
+        rms_values = None
+        source = None
+        if all("RMS" in ds for ds in datasets):
+            rms_values = np.array([float(np.atleast_1d(ds.RMS.values)[0]) for ds in datasets])
+            source = "the stored RMS"
+        elif all("RESIDUAL" in ds for ds in datasets):
+            rms_values = np.array(
+                [float(np.std(ds.RESIDUAL.values / np.atleast_1d(ds.WSUM.values)[:, None, None])) for ds in datasets]
+            )
+            source = "the stored RESIDUAL"
+        if rms_values is not None:
+            rms_mfs = float(np.sum(rms_values * weights) / weights.sum())
+            threshold_val = threshold * rms_mfs
+            log.info("Threshold is %s times the rms from %s", threshold, source)
+        else:
+            finite = cube[np.isfinite(cube)]
+            threshold_val = float(finite.max()) / max_dr if finite.size else 0.0
+            log.info("No rms available. Setting threshold from a max dynamic range of %s", max_dr)
+        log.info("Threshold set to %s Jy", threshold_val)
 
-    log.info("Fitting %s components", ncomps)
-    alpha, alpha_err, Iref, i0_err = fit_spi_components(
-        fitcube, weights, freqsdask, np.float64(ref_freq), beam=beam_comps
-    ).compute()
-    log.info("Done. Writing output.")
+        # the fit runs on Stokes I; other correlations are carried in the header only
+        image = cube[:, 0]
+        pbeam = beam[:, 0]
+        fit_beam = np.ones_like(pbeam) if flux_scale == "intrinsic" else pbeam
 
-    alphamap = np.zeros(model[0].shape, dtype=model.dtype)
-    alphamap[...] = np.nan
-    alpha_err_map = np.zeros(model[0].shape, dtype=model.dtype)
-    alpha_err_map[...] = np.nan
-    i0map = np.zeros(model[0].shape, dtype=model.dtype)
-    i0map[...] = np.nan
-    i0_err_map = np.zeros(model[0].shape, dtype=model.dtype)
-    i0_err_map[...] = np.nan
-    alphamap[maskindices[:, 0], maskindices[:, 1]] = alpha
-    alpha_err_map[maskindices[:, 0], maskindices[:, 1]] = alpha_err
-    i0map[maskindices[:, 0], maskindices[:, 1]] = Iref
-    i0_err_map[maskindices[:, 0], maskindices[:, 1]] = i0_err
-    Irec_cube = i0map[None, :, :] * (freqs[:, None, None] / ref_freq) ** alphamap[None, :, :]
-    fit_diff = np.zeros_like(model)
-    fit_diff[...] = np.nan
-    ix = maskindices[:, 0]
-    iy = maskindices[:, 1]
-    fit_diff[:, ix, iy] = model[:, ix, iy] / beam_image[:, ix, iy]
-    fit_diff[:, ix, iy] -= Irec_cube[:, ix, iy]
+        masked = np.where(pbeam > pb_min, image, np.nan)
+        minimage = np.nanmin(masked, axis=0)
+        maskindices = np.argwhere(np.isfinite(minimage) & (minimage > threshold_val))
+        if not maskindices.size:
+            raise ValueError(
+                "No components found above threshold. Try lowering your threshold. "
+                f"Max of the image is {np.nanmax(image):3.2e}"
+            )
+        fitcube = image[:, maskindices[:, 0], maskindices[:, 1]].T
+        beam_comps = fit_beam[:, maskindices[:, 0], maskindices[:, 1]].T
 
-    if "I" in products:
-        # get the reconstructed cube
-        name = outfile + ".Irec_cube.fits"
-        save_fits(
-            name,
-            np.expand_dims(Irec_cube, axis=4 - stokes_axis),
-            mhdr,
-            dtype=out_dtype,
-        )
-        log.info("Wrote reconstructed cube to %s", name)
+        ncomps = fitcube.shape[0]
+        cchunks = max(1, ncomps // nthreads)
+        log.info("Fitting %s components", ncomps)
+        alpha, alpha_err, i0, i0_err = fit_spi_components(
+            da.from_array(fitcube.astype(np.float64), chunks=(cchunks, nband)),
+            da.from_array(weights.astype(np.float64), chunks=(nband,)),
+            da.from_array(freqs.astype(np.float64), chunks=(nband,)),
+            np.float64(nu_ref),
+            beam=da.from_array(beam_comps.astype(np.float64), chunks=(cchunks, nband)),
+        ).compute()
+        log.info("Done. Writing output.")
 
-    if "d" in products:
-        # get the reconstructed cube
-        name = outfile + ".fit_diff.fits"
-        save_fits(
-            name,
-            np.expand_dims(fit_diff, axis=4 - stokes_axis),
-            mhdr,
-            dtype=out_dtype,
-        )
-        log.info("Wrote reconstructed cube to %s", name)
+        maps = {}
+        for name, values in (
+            ("alpha", alpha),
+            ("alpha_err", alpha_err),
+            ("I0", i0),
+            ("I0_err", i0_err),
+        ):
+            plane = np.full((ny, nx), np.nan, dtype=np.float64)
+            plane[maskindices[:, 0], maskindices[:, 1]] = values
+            maps[name] = plane
 
-    # save alpha map
-    if "a" in products:
-        name = outfile + ".alpha.fits"
-        save_fits(name, alphamap, mhdr, dtype=out_dtype)
-        log.info("Wrote alpha map to %s", name)
+        irec = maps["I0"][None] * (freqs[:, None, None] / nu_ref) ** maps["alpha"][None]
+        fit_diff = np.full_like(irec, np.nan)
+        rows, cols = maskindices[:, 0], maskindices[:, 1]
+        with np.errstate(invalid="ignore", divide="ignore"):
+            fit_diff[:, rows, cols] = image[:, rows, cols] / np.where(
+                fit_beam[:, rows, cols] > 0, fit_beam[:, rows, cols], np.nan
+            )
+        fit_diff[:, rows, cols] -= irec[:, rows, cols]
 
-    # save alpha error map
-    if "e" in products:
-        name = outfile + ".alpha_err.fits"
-        save_fits(name, alpha_err_map, mhdr, dtype=out_dtype)
-        log.info("Wrote alpha error map to %s", name)
+        radec = (float(ref.attrs["ra"]), float(ref.attrs["dec"]))
+        time_out = ref.attrs.get("time_out")
 
-    # save I0 map
-    if "i" in products:
-        name = outfile + ".I0.fits"
-        save_fits(name, i0map, mhdr, dtype=out_dtype)
-        log.info("Wrote I0 map to %s", name)
+        def _write(letter, suffix, data, freq, ref=ref, tid=tid, psfparsf=psfparsf, radec=radec, time_out=time_out):
+            """Write one product. data is always (nband, ncorr, ny, nx)."""
+            if letter not in products:
+                return
+            hdr = set_wcs(
+                cell_deg,
+                cell_deg,
+                nx,
+                ny,
+                radec,
+                freq,
+                unit="Jy/beam",
+                gausspar=psfparsf[0],
+                ms_time=time_out,
+                time_is_unix=True,
+                l0=float(ref.attrs.get("l0", 0.0)),
+                m0=float(ref.attrs.get("m0", 0.0)),
+            )
+            name = f"{output_filename}_time{tid}.{suffix}.fits"
+            save_fits(name, data, hdr, dtype=out_dtype, yx_order=True)
+            log.info("Wrote %s", name)
 
-    # save I0 error map
-    if "k" in products:
-        name = outfile + ".I0_err.fits"
-        save_fits(name, i0_err_map, mhdr, dtype=out_dtype)
-        log.info("Wrote I0 error map to %s", name)
+        _write("a", "alpha", maps["alpha"][None, None], nu_ref)
+        _write("e", "alpha_err", maps["alpha_err"][None, None], nu_ref)
+        _write("i", "I0", maps["I0"][None, None], nu_ref)
+        _write("k", "I0_err", maps["I0_err"][None, None], nu_ref)
+        _write("I", "Irec_cube", irec[:, None], freqs)
+        _write("d", "fit_diff", fit_diff[:, None], freqs)
+        _write("b", "power_beam", pbeam[:, None], freqs)
 
     log.info("All done here")

--- a/src/spimple/core/spifit.py
+++ b/src/spimple/core/spifit.py
@@ -66,13 +66,37 @@ def spifit(
         if dropped:
             log.info("Dropping bands %s", sorted(dropped))
 
+        # A fully flagged band carries WSUM == 0. pfb leaves such nodes in the
+        # tree and its restore skips them, so they may not even carry the
+        # product variable; keeping one would either abort the fit below or
+        # give a dead band a weight.
+        dead = [n for n in keep if "WSUM" in dt[n].ds and not float(np.sum(dt[n].ds.WSUM.values)) > 0]
+        if dead:
+            log.info(
+                "Skipping fully flagged bands %s (WSUM == 0)",
+                [int(dt[n].ds.attrs["bandid"]) for n in dead],
+            )
+            keep = [n for n in keep if n not in set(dead)]
+        if not keep:
+            raise ValueError(f"No bands left at timeid {tid} after dropping deselected and fully flagged bands")
+
         for node in keep:
             if column not in dt[node].ds:
-                hint = (
-                    "run spimple mosaic to combine its partitions"
-                    if partition_nodes(dt, node)
-                    else "the tree carries no such product"
-                )
+                available = sorted(v for v in PRODUCT_VARS.values() if v in dt[node].ds)
+                if partition_nodes(dt, node) and not available:
+                    hint = "run spimple mosaic to combine its partitions"
+                elif available:
+                    scales = ", ".join(
+                        f"{name} for --flux-scale {scale}"
+                        for scale, name in (("apparent", "BIMAGE"), ("intrinsic", "IMAGE"), ("mixed", "KIMAGE"))
+                        if name in available
+                    )
+                    hint = (
+                        f"the tree carries {scales}. Note pfb restore defaults to --outputs kK, "
+                        "which writes KIMAGE only"
+                    )
+                else:
+                    hint = "the tree carries no restored product at all"
                 raise ValueError(f"{node} has no {column}; {hint}")
         datasets = [dt[n].ds for n in keep]
         if len(datasets) < 2:

--- a/src/spimple/core/spifit.py
+++ b/src/spimple/core/spifit.py
@@ -23,7 +23,7 @@ _SCALES = {"apparent": "a", "intrinsic": "i", "mixed": "k"}
 def spifit(
     store: str,
     output_filename: str,
-    flux_scale: str = "apparent",
+    flux_scale: str,
     products: str = "aeikId",
     threshold: float = 10.0,
     max_dr: float = 1000.0,
@@ -40,6 +40,11 @@ def spifit(
     The tree must already be homogenised to a single resolution, by spimple init
     or by pfb restore with a target resolution. Multi partition trees written by
     spimple init must be combined with spimple mosaic first.
+
+    flux_scale has no default deliberately: the three scales carry different
+    physical meanings and which products a tree even holds depends on how it was
+    made, so the caller states which one they are fitting rather than having one
+    chosen for them.
     """
     log_options(log, **locals())
 

--- a/src/spimple/utils/beamsource.py
+++ b/src/spimple/utils/beamsource.py
@@ -1,0 +1,174 @@
+"""Primary-beam backends for the ingest path.
+
+Every backend returns a (nband, ncorr, ny, nx) power beam on the grid described
+by a celestial WCS, in (Y, X) order like everything else on the tree path.
+
+Reprojection follows the construction validated in pfb-imaging's
+docs/wiki/image-and-beam-orientation.md section 6: describe the beam's own grid
+honestly with signed CDELT and a coordinate-derived CRPIX, and make the target
+WCS equal the real output header. The pre-refactor utils/mosaic.project violated
+two of those three -- a one-pixel CRPIX shift and a flipped CDELT1 sign.
+"""
+
+import numpy as np
+from astropy.wcs import WCS
+
+from spimple.utils.logging import get_logger
+
+log = get_logger("BEAM")
+
+_JIMBEAM = {"l": "MKAT-AA-L-JIM-2020", "uhf": "MKAT-AA-UHF-JIM-2020", "s": "MKAT-AA-S-JIM-2020"}
+
+
+def lm_grid(wcs, shape: tuple[int, int]) -> tuple[np.ndarray, np.ndarray]:
+    """Return the (ny, nx) direction-cosine grids in degrees.
+
+    For a SIN projection the intermediate world coordinate
+    ``(pixel - crpix) * cdelt`` is the direction cosine itself, so no projection
+    maths is needed. l runs along x and decreases (CDELT1 is negative); m runs
+    along y and increases.
+
+    Args:
+        wcs: A 2-axis celestial WCS.
+        shape: (ny, nx).
+
+    Returns:
+        (ll, mm), both (ny, nx), in degrees, zero at the reference pixel.
+    """
+    ny, nx = shape
+    cdelt = wcs.wcs.cdelt
+    crpix = wcs.wcs.crpix
+    l_axis = (np.arange(nx) - (crpix[0] - 1)) * cdelt[0]
+    m_axis = (np.arange(ny) - (crpix[1] - 1)) * cdelt[1]
+    # meshgrid's default indexing gives (len(m), len(l)) == (ny, nx)
+    return np.meshgrid(l_axis, m_axis)
+
+
+def _reproject_plane(plane: np.ndarray, ref_wcs, target_wcs, shape: tuple[int, int]) -> np.ndarray:
+    """Reproject one (ny, nx) plane onto the target WCS, zeroing outside the footprint."""
+    from reproject import reproject_interp
+
+    out, footprint = reproject_interp((plane, ref_wcs), target_wcs, shape_out=shape)
+    out = np.nan_to_num(out, nan=0.0)
+    out[footprint <= 0] = 0.0
+    return out
+
+
+def _wcs_from_coords(l_deg: np.ndarray, m_deg: np.ndarray, radec_deg: tuple[float, float]) -> WCS:
+    """Build the reference WCS of a beam grid from its own coordinates.
+
+    Signed CDELT from the coordinate spacing, CRPIX from where zero falls -- the
+    two things the old project() got wrong.
+    """
+    dl = float(l_deg[1] - l_deg[0])
+    dm = float(m_deg[1] - m_deg[0])
+    w = WCS(naxis=2)
+    w.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    w.wcs.cdelt = [dl, dm]
+    w.wcs.crval = list(radec_deg)
+    w.wcs.crpix = [1 + (0.0 - float(l_deg[0])) / dl, 1 + (0.0 - float(m_deg[0])) / dm]
+    w.array_shape = (m_deg.size, l_deg.size)
+    return w
+
+
+def _jimbeam(band: str, freqs: np.ndarray, wcs, shape: tuple[int, int]) -> np.ndarray:
+    from katbeam import JimBeam
+
+    key = band.lower()
+    if key not in _JIMBEAM:
+        raise ValueError(f"Unknown band {band} for katbeam, expected one of {sorted(_JIMBEAM)}")
+    jim = JimBeam(_JIMBEAM[key])
+    ll, mm = lm_grid(wcs, shape)
+    return np.stack([jim.I(ll, mm, float(freq) / 1e6) for freq in freqs])
+
+
+def _fits_beam(path: str, freqs: np.ndarray, wcs, shape: tuple[int, int]) -> np.ndarray:
+    from astropy.io import fits
+
+    from spimple.utils.fits import load_cube
+
+    cube, bfreqs = load_cube(path, dtype=np.float64)  # (nband, ncorr, ny, nx)
+    ref_wcs = WCS(fits.getheader(path)).celestial
+    out = np.empty((freqs.size, shape[0], shape[1]), dtype=np.float64)
+    for i, freq in enumerate(freqs):
+        nearest = int(np.argmin(np.abs(bfreqs - freq)))
+        out[i] = _reproject_plane(cube[nearest, 0], ref_wcs, wcs, shape)
+    return out
+
+
+def _bds_beam(path: str, freqs: np.ndarray, wcs, shape: tuple[int, int], radec_deg) -> np.ndarray:
+    """Rotation-averaged power beam from a meerkat-beams bds zarr store."""
+    import xarray as xr
+    from scipy import ndimage
+    from scipy.interpolate import RegularGridInterpolator
+
+    bds = xr.open_zarr(path, chunks=None)
+    # meerkat-beams has used both spellings for the beam grid coordinates
+    l_name = "l_beam" if "l_beam" in bds.coords or "l_beam" in bds else "X"
+    m_name = "m_beam" if "m_beam" in bds.coords or "m_beam" in bds else "Y"
+    l_beam = np.asarray(bds[l_name].values, dtype=float)
+    m_beam = np.asarray(bds[m_name].values, dtype=float)
+    bfreq = np.asarray(bds.chan.values, dtype=float)
+    jones = bds.BEAM.values  # (ncorr, nchan, ny, nx) on the beam's own grid
+    power = ((jones[0] * jones[0].conj()).real + (jones[-1] * jones[-1].conj()).real) / 2.0
+
+    interp = RegularGridInterpolator(
+        (bfreq, m_beam, l_beam), power, bounds_error=False, fill_value=None, method="linear"
+    )
+    ref_wcs = _wcs_from_coords(l_beam, m_beam, radec_deg)
+    ll, mm = np.meshgrid(l_beam, m_beam)
+
+    out = np.empty((freqs.size, shape[0], shape[1]), dtype=np.float64)
+    angles = np.linspace(0, 359, 25)
+    for i, freq in enumerate(freqs):
+        plane = interp((float(freq), mm, ll))
+        rotated = np.zeros_like(plane)
+        for angle in angles:
+            rotated += ndimage.rotate(plane, angle, reshape=False, order=1, mode="nearest")
+        rotated /= angles.size
+        out[i] = _reproject_plane(rotated, ref_wcs, wcs, shape)
+    return out
+
+
+def beam_for_grid(
+    beam_model: str | None,
+    band: str,
+    freqs: np.ndarray,
+    wcs,
+    shape: tuple[int, int],
+    ncorr: int,
+    nthreads: int = 1,
+) -> np.ndarray:
+    """Evaluate a power beam on an image grid.
+
+    Args:
+        beam_model: None for a uniform response, the literal "JimBeam", a path
+            ending in .fits for a beam cube, or a path to a bds zarr store.
+        band: JimBeam band, one of L, UHF or S.
+        freqs: (nband,) frequencies in Hz.
+        wcs: The 2-axis celestial WCS of the target grid.
+        shape: (ny, nx) of the target grid.
+        ncorr: Number of correlations. The Stokes I power beam is broadcast.
+        nthreads: Unused today; kept so callers need not special-case backends.
+
+    Returns:
+        (nband, ncorr, ny, nx) in [0, 1].
+
+    Raises:
+        ValueError: If beam_model is not one of the supported forms.
+    """
+    freqs = np.atleast_1d(np.asarray(freqs, dtype=float))
+    if beam_model is None:
+        planes = np.ones((freqs.size, shape[0], shape[1]), dtype=np.float64)
+    else:
+        name = str(beam_model)
+        if name == "JimBeam":
+            planes = _jimbeam(band, freqs, wcs, shape)
+        elif name.endswith(".fits"):
+            planes = _fits_beam(name, freqs, wcs, shape)
+        elif name.rstrip("/").endswith(".zarr"):
+            radec = (float(wcs.wcs.crval[0]), float(wcs.wcs.crval[1]))
+            planes = _bds_beam(name, freqs, wcs, shape, radec)
+        else:
+            raise ValueError(f"Unknown beam model {beam_model}; expected JimBeam, a .fits cube or a .zarr store")
+    return np.repeat(planes[:, None], ncorr, axis=1)

--- a/src/spimple/utils/convolution.py
+++ b/src/spimple/utils/convolution.py
@@ -32,16 +32,19 @@ def Gaussian2D(xin, yin, GaussPar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
     R = np.array([[np.sin(PA), -np.cos(PA)], [np.cos(PA), np.sin(PA)]])
     A = np.dot(np.dot(R.T, A), R)
     sOut = xin.shape
-    # only compute the result out to 5 * emaj
-    extent = (nsigma * Smaj) ** 2
+    # the docstring's contract: nsigma standard deviations of the major axis
+    sigma_maj = Smaj / (2 * np.sqrt(2 * np.log(2)))
+    extent = (nsigma * sigma_maj) ** 2
     xflat = xin.squeeze()
     yflat = yin.squeeze()
     idx, idy = np.where(xflat**2 + yflat**2 <= extent)
     x = np.array([xflat[idx, idy].ravel(), yflat[idx, idy].ravel()])
     R = np.einsum("nb,bc,cn->n", x.T, A, x)
-    # need to adjust for the fact that GaussPar corresponds to FWHM
+    # GaussPar is FWHM: a Gaussian with FWHM S needs exp(-4 ln2 x^2 / S^2),
+    # i.e. the coefficient is 0.5 * fwhm_conv**2, not fwhm_conv. The previous
+    # form made every kernel 8.51% too wide.
     fwhm_conv = 2 * np.sqrt(2 * np.log(2))
-    tmp = np.exp(-fwhm_conv * R)
+    tmp = np.exp(-0.5 * fwhm_conv**2 * R)
     gausskern = np.zeros(xflat.shape, dtype=np.float64)
     gausskern[idx, idy] = tmp
 

--- a/src/spimple/utils/convolution.py
+++ b/src/spimple/utils/convolution.py
@@ -123,8 +123,10 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads, gausspari=None, pfrac=
     image = np.pad(image, padding, mode="constant").astype(np.float64)
     imhat = r2c(iFs(image, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
 
-    # convolve to desired resolution
-    if gausspari in [None, ()]:
+    # convolve to desired resolution. Not `gausspari in [None, ()]`: that is an
+    # elementwise comparison for a numpy array and raises "truth value of an
+    # array is ambiguous". The legacy callers only ever passed tuples.
+    if gausspari is None or np.size(gausspari) == 0:
         imhat *= gausskernhat
     else:
         for i in range(nband):

--- a/src/spimple/utils/convolution.py
+++ b/src/spimple/utils/convolution.py
@@ -69,32 +69,56 @@ def get_padding_info(nx, ny, pfrac):
     return padding, unpad_x, unpad_y
 
 
-def convolve2gaussres(image, xx, yy, gaussparf, nthreads, gausspari=None, pfrac=0.5, norm_kernel=False):
+def convolve2gaussres(image, xx, yy, gaussparf, nthreads, gausspari=None, pfrac=0.5, norm_kernel=False, yx_order=False):
     """
     Convolves the image to a specified resolution.
 
     Parameters
     ----------
-    Image - (nband, nx, ny) array to convolve
-    xx/yy - coordinates on the grid in the same units as gaussparf.
-    gaussparf - tuple containing Gaussian parameters of desired resolution
-                (emaj, emin, pa).
-    gausspari - initial resolution . By default it is assumed that the image
+    image - (nband, nx, ny) array to convolve, or (nband, ny, nx) with yx_order.
+    xx/yy - coordinates on the grid in the same units as gaussparf. ALWAYS built
+            x-major, from nx then ny, whatever yx_order is.
+    gaussparf - Gaussian parameters of the desired resolution (emaj, emin, pa),
+                either shared by every plane as a (3,) tuple or per plane as a
+                (nband, 3) array.
+    gausspari - initial resolution. By default it is assumed that the image
                 is a clean component image with no associated resolution.
-                If beampari is specified, it must be a tuple containing gausspars
-                for each imaging band in the same format.
+                If specified, it must contain gausspars for each imaging band
+                in the same format.
     nthreads - number of threads to use for the FFT's.
     pfrac - padding used for the FFT based convolution. Will pad by pfrac/2 on
             both sides of image
+    norm_kernel - normalise the Gaussian kernel to have volume 1.
+    yx_order - set True for (Y, X)-ordered DataTree arrays. The convolution is
+               defined x-major; this transposes in and out so the position angle
+               keeps its meaning.
     """
+    if yx_order:
+        image = image.transpose(0, 2, 1)
     nband, nx, ny = image.shape
+
+    gaussparf = np.asarray(gaussparf, dtype=np.float64)
+    per_plane = gaussparf.ndim > 1
+    if per_plane and gaussparf.shape[0] != nband:
+        raise ValueError(f"gaussparf must be of length {nband}, got {gaussparf.shape[0]}")
+    if gausspari is not None and np.ndim(gausspari) > 1 and np.shape(gausspari)[0] != nband:
+        raise ValueError(f"gausspari must be of length {nband}, got {np.shape(gausspari)[0]}")
+
     padding, unpad_x, unpad_y = get_padding_info(nx, ny, pfrac)
     ax = (1, 2)  # axes over which to perform fft
     lastsize = ny + np.sum(padding[-1])
 
-    gausskern = Gaussian2D(xx, yy, gaussparf, normalise=norm_kernel)
-    gausskern = np.pad(gausskern[None], padding, mode="constant")
-    gausskernhat = r2c(iFs(gausskern, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
+    if per_plane:
+        gausskern = np.stack([Gaussian2D(xx, yy, tuple(gaussparf[i]), normalise=norm_kernel) for i in range(nband)])
+    else:
+        gausskern = Gaussian2D(xx, yy, tuple(gaussparf), normalise=norm_kernel)[None]
+    gausskernhat = r2c(
+        iFs(np.pad(gausskern, padding, mode="constant"), axes=ax),
+        axes=ax,
+        forward=True,
+        nthreads=nthreads,
+        inorm=0,
+    )
 
     image = np.pad(image, padding, mode="constant").astype(np.float64)
     imhat = r2c(iFs(image, axes=ax), axes=ax, forward=True, nthreads=nthreads, inorm=0)
@@ -104,7 +128,7 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads, gausspari=None, pfrac=
         imhat *= gausskernhat
     else:
         for i in range(nband):
-            thiskern = Gaussian2D(xx, yy, gausspari[i], normalise=norm_kernel).astype(np.float64)
+            thiskern = Gaussian2D(xx, yy, tuple(gausspari[i]), normalise=norm_kernel).astype(np.float64)
             thiskern = np.pad(thiskern[None], padding, mode="constant")
             thiskernhat = r2c(
                 iFs(thiskern, axes=ax),
@@ -114,17 +138,20 @@ def convolve2gaussres(image, xx, yy, gaussparf, nthreads, gausspari=None, pfrac=
                 inorm=0,
             )
 
+            target = gausskernhat[i] if per_plane else gausskernhat[0]
             if not np.all(np.isnan(thiskernhat)):
-                convkernhat = np.where(np.abs(thiskernhat) > 1e-10, gausskernhat / thiskernhat, 0.0)
+                convkernhat = np.where(np.abs(thiskernhat[0]) > 1e-10, target / thiskernhat[0], 0.0)
             else:
                 print("Nan values have been encountered. Subverting RuntimeWarning")
-                convkernhat = np.zeros_like(thiskernhat).astype("complex")
+                convkernhat = np.zeros_like(thiskernhat[0]).astype("complex")
 
-            imhat[i] *= convkernhat[0]
+            imhat[i] *= convkernhat
 
     image = Fs(
         c2r(imhat, axes=ax, forward=False, lastsize=lastsize, inorm=2, nthreads=nthreads),
         axes=ax,
     )[:, unpad_x, unpad_y]
 
-    return image, gausskern[:, unpad_x, unpad_y]
+    if yx_order:
+        return image.transpose(0, 2, 1), gausskern.transpose(0, 2, 1)
+    return image, gausskern

--- a/src/spimple/utils/convolution.py
+++ b/src/spimple/utils/convolution.py
@@ -32,9 +32,15 @@ def Gaussian2D(xin, yin, GaussPar=(1.0, 1.0, 0.0), normalise=True, nsigma=5):
     R = np.array([[np.sin(PA), -np.cos(PA)], [np.cos(PA), np.sin(PA)]])
     A = np.dot(np.dot(R.T, A), R)
     sOut = xin.shape
-    # the docstring's contract: nsigma standard deviations of the major axis
-    sigma_maj = Smaj / (2 * np.sqrt(2 * np.log(2)))
-    extent = (nsigma * sigma_maj) ** 2
+    # Support is nsigma MAJOR-AXIS FWHMs, not nsigma standard deviations, and it
+    # has to stay this wide. convolve2gaussres divides by this kernel's transform
+    # when gausspari is given, and a Gaussian's transform decays to ~1e-14 by
+    # Nyquist. Truncating at 5 sigma leaves a step of 3.7e-6 of peak whose
+    # spectral ripple then dominates that 1e-14 -- the division amplifies it into
+    # ringing that displaces the peak. At 5 FWHM (11.8 sigma) the step is ~4e-31
+    # and the division is clean. Pinned by
+    # test_convolve2gaussres_preserves_position_when_deconvolving.
+    extent = (nsigma * Smaj) ** 2
     xflat = xin.squeeze()
     yflat = yin.squeeze()
     idx, idy = np.where(xflat**2 + yflat**2 <= extent)

--- a/src/spimple/utils/datatree.py
+++ b/src/spimple/utils/datatree.py
@@ -1,0 +1,187 @@
+"""The DataTree schema layer.
+
+The only module that knows the store layout. Everything else goes through it,
+so the cross-repo contract with pfb-imaging has exactly one owner. See
+``docs/wiki/datatree-contract.md``.
+
+Node naming, array order, units and iteration order all matter and are pinned
+by ``tests/test_datatree.py``:
+
+* nodes are ``band{bandid:04d}_time{timeid:04d}`` with ``part{pid:04d}`` children;
+* image variables are ``(corr, y, x)``;
+* ``PSFPARSN``/``PSFPARSF`` are ``(emaj, emin, pa)`` in pixels, pixels, radians;
+* bands are iterated sorted by ``bandid``, never by ``freq_out`` -- effective
+  frequencies are data-dependent and asymmetric flagging can invert two bands.
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+
+# CLI letter -> band-node variable, matching pfb's restore contract. The B
+# prefix follows the tree's convention for beam-attenuated quantities.
+PRODUCT_VARS = {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}
+
+BPAR = ["BMAJ", "BMIN", "BPA"]
+
+
+def band_node_name(bandid: int, timeid: int) -> str:
+    """Return the group path of a band node."""
+    return f"band{bandid:04d}_time{timeid:04d}"
+
+
+def partition_node_name(pid: int) -> str:
+    """Return the group name of a partition child."""
+    return f"part{pid:04d}"
+
+
+def create_store(url: str, attrs: dict, overwrite: bool = False) -> None:
+    """Create the store root, carrying the root attributes.
+
+    Args:
+        url: Store path.
+        attrs: Root attributes.
+        overwrite: Replace an existing store.
+
+    Raises:
+        FileExistsError: If the store exists and overwrite is False.
+    """
+    if Path(url).exists() and not overwrite:
+        raise FileExistsError(f"{url} exists, pass overwrite to replace it")
+    xr.Dataset(attrs=attrs).to_zarr(url, mode="w", consolidated=False)
+
+
+def open_store(url: str) -> xr.DataTree:
+    """Open a store lazily, without chunking.
+
+    ``consolidated=False`` matches how every write here is made; without it
+    xarray tries the consolidated metadata first, fails, and warns on every
+    open.
+    """
+    return xr.open_datatree(url, engine="zarr", chunks=None, consolidated=False)
+
+
+def write_node(url: str, node: str, data_vars: dict, attrs: dict, coords: dict) -> None:
+    """Write or extend one group, merging attributes.
+
+    ``to_zarr(mode="a")`` replaces a group's attrs wholesale, so an incremental
+    write must start from whatever the group already carries. Callers therefore
+    pass only the attrs they are adding.
+
+    Args:
+        url: Store path.
+        node: Group path relative to the root, e.g. ``band0000_time0000/part0000``.
+        data_vars: Mapping suitable for ``xr.Dataset``.
+        attrs: Attributes to merge into the group's existing attributes.
+        coords: Coordinates for the dataset.
+    """
+    existing = {}
+    try:
+        existing = dict(xr.open_zarr(url, group=node, chunks=None, consolidated=False).attrs)
+    except (FileNotFoundError, KeyError, OSError):
+        pass
+    xr.Dataset(data_vars, coords=coords, attrs={**existing, **attrs}).to_zarr(
+        url, group=node, mode="a", consolidated=False
+    )
+
+
+def timeids(dt: xr.DataTree) -> list[int]:
+    """Return the sorted distinct timeids present in the tree."""
+    return sorted({int(dt[name].ds.attrs["timeid"]) for name in dt.children if name.startswith("band")})
+
+
+def band_nodes(dt: xr.DataTree, timeid: int | None = None) -> list[str]:
+    """Return band-node names sorted by bandid, optionally filtered by timeid."""
+    names = [name for name in dt.children if name.startswith("band")]
+    if timeid is not None:
+        names = [name for name in names if int(dt[name].ds.attrs["timeid"]) == timeid]
+    return sorted(names, key=lambda name: int(dt[name].ds.attrs["bandid"]))
+
+
+def partition_nodes(dt: xr.DataTree, node: str) -> list[str]:
+    """Return the partition child names of a band node, sorted by pid."""
+    return sorted(name for name in dt[node].children if name.startswith("part"))
+
+
+def require_vars(ds: xr.Dataset, names: Sequence[str], node: str, hint: str) -> None:
+    """Raise unless every named variable is present.
+
+    Args:
+        ds: The band or partition dataset.
+        names: Required variable names.
+        node: Node path, for the message.
+        hint: What the user should do, named explicitly.
+
+    Raises:
+        ValueError: If any variable is missing.
+    """
+    missing = [name for name in names if name not in ds]
+    if missing:
+        raise ValueError(f"{node} has no {', '.join(missing)}; {hint}")
+
+
+def check_homogeneous(datasets: Sequence[xr.Dataset]) -> np.ndarray:
+    """Return the common PSFPARSF, raising unless every band agrees.
+
+    A spectral index fit needs every band at one resolution. A tree is
+    homogeneous when ``spimple init`` or ``pfb restore --gausspar`` produced it.
+
+    Args:
+        datasets: The band datasets, in bandid order.
+
+    Returns:
+        The shared ``(ncorr, 3)`` resolution in pixels, pixels, radians.
+
+    Raises:
+        ValueError: If PSFPARSF is absent anywhere, or the bands disagree.
+    """
+    for i, ds in enumerate(datasets):
+        if "PSFPARSF" not in ds:
+            raise ValueError(
+                f"band {i} has no PSFPARSF; run spimple init or pfb restore --gausspar to "
+                "homogenise the resolution before fitting"
+            )
+    ref = np.asarray(datasets[0].PSFPARSF.values, dtype=float)
+    for i, ds in enumerate(datasets[1:], 1):
+        pars = np.asarray(ds.PSFPARSF.values, dtype=float)
+        if not np.allclose(ref, pars, rtol=1e-6, atol=0.0):
+            raise ValueError(
+                f"band {i} is at a different resolution to band 0 ({pars[0]} vs {ref[0]} pixels); "
+                "run spimple init or pfb restore --gausspar to homogenise them"
+            )
+    return ref
+
+
+def psfpars_from_header(hdr, nband: int, ncorr: int, cell_deg: float) -> np.ndarray:
+    """Synthesise PSFPARSN from a FITS header's beam cards.
+
+    FITS input carries no PSF array, so the native resolution comes from the
+    per-plane ``BMAJ{i}``/``BMIN{i}``/``BPA{i}`` cards, falling back to the
+    scalar ``BMAJ``/``BMIN``/``BPA`` broadcast over every band.
+
+    Args:
+        hdr: FITS header.
+        nband: Number of bands.
+        ncorr: Number of correlations.
+        cell_deg: Cell size in degrees.
+
+    Returns:
+        ``(nband, ncorr, 3)`` in pixels, pixels, radians.
+
+    Raises:
+        ValueError: If the header carries no beam parameters at all.
+    """
+    pars = np.full((nband, 3), np.nan, dtype=np.float64)
+    for band in range(nband):
+        key = f"BMAJ{band + 1}"
+        if key in hdr:
+            pa = hdr.get(f"BPA{band + 1}", hdr.get(f"PA{band + 1}", 0.0))
+            pars[band] = (hdr[key] / cell_deg, hdr[f"BMIN{band + 1}"] / cell_deg, np.deg2rad(pa))
+    if np.isnan(pars).any():
+        if "BMAJ" not in hdr:
+            raise ValueError("No BMAJ in the header and no per-plane BMAJ cards; pass psf-pars explicitly")
+        scalar = (hdr["BMAJ"] / cell_deg, hdr["BMIN"] / cell_deg, np.deg2rad(hdr.get("BPA", 0.0)))
+        pars = np.where(np.isnan(pars), np.array(scalar)[None], pars)
+    return np.tile(pars[:, None, :], (1, ncorr, 1))

--- a/src/spimple/utils/fits.py
+++ b/src/spimple/utils/fits.py
@@ -201,7 +201,9 @@ def set_wcs(
             header["CASAMBM"] = casambm  # we need this to pick up the beams table
 
         if gausspar is not None or gausspars is not None:
-            header = add_beampars(header, gausspar, gausspars=gausspars)
+            # gausspar/gausspars arrive in pixels (the PSFPARSF convention) with
+            # the angle in radians; unit2deg converts the axes to degrees.
+            header = add_beampars(header, gausspar, GaussPars=gausspars, unit2deg=cell_x)
 
         return header
     return w

--- a/src/spimple/utils/fits.py
+++ b/src/spimple/utils/fits.py
@@ -26,15 +26,78 @@ def data_from_header(hdr, axis=3):
     return ref_val + np.arange(1 - refpix, 1 + npix - refpix) * delta, ref_val
 
 
+def freq_axis_of(hdr) -> int:
+    """Return the FITS axis number carrying frequency, 3 or 4.
+
+    Args:
+        hdr: FITS header.
+
+    Returns:
+        3 or 4.
+
+    Raises:
+        ValueError: If neither CTYPE3 nor CTYPE4 is a frequency axis.
+    """
+    for axis in (4, 3):
+        ctype = hdr.get(f"CTYPE{axis}", "")
+        if str(ctype).lower() in ("freq", "speclnmf"):
+            return axis
+    raise ValueError("Freq axis must be 3rd or 4th")
+
+
 def load_fits(name, dtype=np.float32):
     data = fits.getdata(name)
     data = np.transpose(to4d(data), axes=(1, 0, 3, 2))  # fits and beams table
     return np.require(data, dtype=dtype, requirements="C")
 
 
-def save_fits(name, data, hdr, overwrite=True, dtype=np.float32, beams_hdu=None):
+def load_cube(name, dtype=np.float32):
+    """Load a FITS cube as (nband, ncorr, ny, nx) with the raster preserved.
+
+    astropy maps numpy axes to FITS axes in reverse, so the data arrives as
+    (NAXIS4, NAXIS3, NAXIS2, NAXIS1). This detects which of NAXIS3/NAXIS4 is
+    frequency and moves it to axis 0, leaving the (ny, nx) raster alone. Use
+    this on the DataTree path; ``load_fits`` keeps its legacy (X, Y) transpose
+    for the FITS-to-FITS commands.
+
+    Args:
+        name: Path to the FITS file.
+        dtype: Output dtype.
+
+    Returns:
+        A tuple of the (nband, ncorr, ny, nx) cube and the (nband,) frequencies.
+    """
+    hdr = fits.getheader(name)
+    data = to4d(fits.getdata(name))
+    axis = freq_axis_of(hdr)
+    # numpy axis 0 is NAXIS4, numpy axis 1 is NAXIS3
+    band_axis = 0 if axis == 4 else 1
+    corr_axis = 1 - band_axis
+    cube = np.transpose(data, axes=(band_axis, corr_axis, 2, 3))
+    freqs, _ = data_from_header(hdr, axis=axis)
+    return np.require(cube, dtype=dtype, requirements="C"), freqs
+
+
+def save_fits(name, data, hdr, overwrite=True, dtype=np.float32, beams_hdu=None, yx_order=False):
+    """Write an array to FITS.
+
+    Args:
+        name: Output path.
+        data: (nband, ncorr, ny, nx) when yx_order is True, otherwise a legacy
+            x-major array that is transposed as it always was.
+        hdr: FITS header.
+        overwrite: Overwrite an existing file.
+        dtype: Output dtype.
+        beams_hdu: Optional BEAMS BinTableHDU appended as an extension.
+        yx_order: True for DataTree-path arrays, which already carry the FITS
+            (ny, nx) raster and need only the band and corr axes swapped onto
+            the FREQ and STOKES axes.
+    """
     hdu = fits.PrimaryHDU(header=hdr)
-    data = np.transpose(to4d(data), axes=(1, 0, 3, 2))
+    if yx_order:
+        data = np.transpose(to4d(data), axes=(1, 0, 2, 3))
+    else:
+        data = np.transpose(to4d(data), axes=(1, 0, 3, 2))
     hdu.data = np.require(data, dtype=dtype, requirements="F")
     if beams_hdu is not None:
         hdul = fits.HDUList([hdu, beams_hdu])
@@ -51,10 +114,14 @@ def set_wcs(
     radec,
     freq,
     unit="Jy/beam",
-    GuassPar=None,
+    gausspar=None,
+    gausspars=None,
     ms_time=None,
+    time_is_unix=False,
     header=True,
     casambm=True,
+    l0=0.0,
+    m0=0.0,
 ):
     """
     cell_x/y - cell sizes in degrees
@@ -62,10 +129,15 @@ def set_wcs(
     radec - right ascention and declination in radians
     freq - frequencies in Hz
     unit - Jy/beam or Jy/pixel
-    GuassPar - MFS beam parameters in degrees
+    gausspar - MFS beam parameters in degrees
+    gausspars - per-plane beam parameters in degrees, for a cube
     ms_time - measurement set time
+    time_is_unix - if True, ms_time is already in unix seconds (the DataTree
+        convention); otherwise it is MSv2 MJD seconds
     header - if True, return a header, otherwise return a WCS object
     casambm - if True, add the CASAMBM keyword to the header
+    l0/m0 - image-centre offset from the tangent point in radians. CRVAL stays
+        the tangent point; CRPIX shifts so the centre pixel lands on the target
     """
 
     w = WCS(naxis=4)
@@ -80,14 +152,20 @@ def set_wcs(
     if np.size(freq) > 1:
         nchan = freq.size
         crpix3 = nchan // 2 + 1
-        ref_freq = freq[crpix3]
+        # CRPIX is one-based; the matching numpy index is crpix3 - 1
+        ref_freq = freq[crpix3 - 1]
         df = freq[1] - freq[0]
         w.wcs.cdelt[2] = df
     else:
-        ref_freq = freq[0] if isinstance(freq, np.ndarray) else freq
+        ref_freq = freq[0] if isinstance(freq, np.ndarray) and freq.size == 1 else freq
         crpix3 = 1
     w.wcs.crval = [radec[0] * 180.0 / np.pi, radec[1] * 180.0 / np.pi, ref_freq, 1]
-    w.wcs.crpix = [1 + nx // 2, 1 + ny // 2, crpix3, 1]
+    # CRVAL stays the tangent point; an l0/m0 offset shifts CRPIX so the centre
+    # pixel lands on the target. The RA axis has cdelt = -cell_x, so its sign is
+    # opposite the Dec axis's.
+    crpix_x = 1 + nx // 2 + np.rad2deg(l0) / cell_x
+    crpix_y = 1 + ny // 2 - np.rad2deg(m0) / cell_y
+    w.wcs.crpix = [crpix_x, crpix_y, crpix3, 1]
     w.wcs.equinox = 2000.0
 
     if header:
@@ -98,9 +176,10 @@ def set_wcs(
         header["BUNIT"] = unit
         header["SPECSYS"] = "TOPOCENT"
         if ms_time is not None:
-            # ms_time is MJD seconds. Truncate to whole seconds before rendering
-            # DATE-OBS so the two header keys agree, as they did via strftime.
-            utc_iso = Time(ms_time / 86400.0, format="mjd", scale="utc").strftime("%Y-%m-%d %H:%M:%S")
+            # MSv2 carries MJD seconds; the DataTree carries unix seconds. Truncate
+            # to whole seconds before rendering DATE-OBS so the two header keys agree.
+            mjd_seconds = ms_time + 3506716800.0 if time_is_unix else ms_time
+            utc_iso = Time(mjd_seconds / 86400.0, format="mjd", scale="utc").strftime("%Y-%m-%d %H:%M:%S")
             header["UTC_TIME"] = utc_iso
             t = Time(utc_iso, scale="utc")
             t.format = "fits"
@@ -121,8 +200,8 @@ def set_wcs(
         if casambm:
             header["CASAMBM"] = casambm  # we need this to pick up the beams table
 
-        if GuassPar is not None:
-            header = add_beampars(header, GuassPar)
+        if gausspar is not None or gausspars is not None:
+            header = add_beampars(header, gausspar, gausspars=gausspars)
 
         return header
     return w
@@ -140,12 +219,13 @@ def add_beampars(hdr, GaussPar, GaussPars=None, unit2deg=1.0):
     pfb/utils/misc/Gaussian2D
 
     """
-    if len(GaussPar) == 1:
-        GaussPar = GaussPar[0]
-    elif len(GaussPar) != 3:
-        raise ValueError("Invalid value for GaussPar")
+    if GaussPar is not None:
+        if len(GaussPar) == 1:
+            GaussPar = GaussPar[0]
+        elif len(GaussPar) != 3:
+            raise ValueError("Invalid value for GaussPar")
 
-    if not np.isnan(GaussPar).any():
+    if GaussPar is not None and not np.isnan(GaussPar).any():
         hdr["BMAJ"] = GaussPar[0] * unit2deg
         hdr["BMIN"] = GaussPar[1] * unit2deg
         hdr["BPA"] = GaussPar[2] * 180 / np.pi
@@ -158,6 +238,47 @@ def add_beampars(hdr, GaussPar, GaussPars=None, unit2deg=1.0):
                 hdr["BPA" + str(i + 1)] = GaussPars[i][2] * 180 / np.pi
 
     return hdr
+
+
+def create_beams_table(beams_data, cell2deg):
+    """Build a CASA-style BEAMS BinTableHDU from per-band, per-corr resolutions.
+
+    Args:
+        beams_data: DataArray with dims (band, corr, bpar) and the bpar
+            coordinate ["BMAJ", "BMIN", "BPA"], in pixels, pixels and radians.
+        cell2deg: Cell size in degrees, converting the axes to degrees.
+
+    Returns:
+        An astropy BinTableHDU named BEAMS.
+    """
+    nband = beams_data.band.size
+    npol = beams_data.corr.size
+    band_id = []
+    pol_id = []
+    for b in range(nband):
+        for p in range(npol):
+            band_id.append(b)
+            pol_id.append(p)
+
+    bmaj = beams_data.sel({"bpar": "BMAJ"}).values.ravel() * cell2deg
+    bmin = beams_data.sel({"bpar": "BMIN"}).values.ravel() * cell2deg
+    bpa = beams_data.sel({"bpar": "BPA"}).values.ravel() * 180 / np.pi
+    cols = fits.ColDefs(
+        [
+            fits.Column(name="BMAJ", format="1E", array=bmaj, unit="deg"),
+            fits.Column(name="BMIN", format="1E", array=bmin, unit="deg"),
+            fits.Column(name="BPA", format="1E", array=bpa, unit="deg"),
+            fits.Column(name="CHAN", format="1J", array=np.array(band_id)),
+            fits.Column(name="POL", format="1J", array=np.array(pol_id)),
+        ]
+    )
+    beams_hdu = fits.BinTableHDU.from_columns(cols)
+    beams_hdu.name = "BEAMS"
+    beams_hdu.header["EXTNAME"] = "BEAMS"
+    beams_hdu.header["EXTVER"] = 1
+    beams_hdu.header["NCHAN"] = nband
+    beams_hdu.header["NPOL"] = npol
+    return beams_hdu
 
 
 def set_header_info(mhdr, ref_freq, freq_axis, beampars=None):

--- a/src/spimple/utils/mosaic.py
+++ b/src/spimple/utils/mosaic.py
@@ -1,185 +1,94 @@
+"""Combine image-space partitions into one band image.
+
+Each partition p carries an apparent image A_p = B_p * S on the union grid,
+masked by its own footprint. The optimal linear combination minimises
+sum_p ||A_p - B_p S||^2, whose normal equations are
+
+    (sum_p B_p^2 + eta) S = sum_p B_p A_p
+
+The operator is diagonal -- purely elementwise -- so the exact solution is one
+division. ``conjugate_gradient`` is kept for the day a non-diagonal term is
+added, and ``tests/test_mosaic.py`` pins the two against each other.
+
+Arrays are (npart, ncorr, ny, nx) with (npart, ny, nx) masks.
+"""
+
 import numpy as np
-import ray
-import xarray as xr
-from astropy.io import fits
-from astropy.wcs import WCS
-from reproject import reproject_interp
-from reproject.mosaicking import find_optimal_celestial_wcs
-from scipy import ndimage
-from scipy.interpolate import RegularGridInterpolator
 
-from spimple.utils.fits import data_from_header
+from spimple.utils.logging import get_logger
+
+log = get_logger("MOSAIC")
 
 
-def mosaic_info(im_list, oname, ref_image=None):
-    if ref_image is not None:
-        raise NotImplementedError("Reference image not supported yet")
-    wcss = []
-    out_names = []
-    freqs = []
-    flatfreqs = []
-    shapes = []
-    basename = oname.removesuffix(".fits")
-    for imnum, im in enumerate(im_list):
-        hdr = fits.getheader(im)
-        nu = data_from_header(hdr, axis=3)[0]
-        freqs.append(nu)
-        flatfreqs.extend(nu)
-        wcsi = WCS(hdr).dropaxis(-1).dropaxis(-1)
-        wcss.append(wcsi)
-        nchan = hdr["NAXIS3"]
-        ncorr = hdr["NAXIS4"]
-        shapes.append((hdr["NAXIS1"], hdr["NAXIS2"]))
-        out_names.extend([f"{basename}_im{imnum}_pol{c}_ch{f}.zarr" for c in range(ncorr) for f in range(nchan)])
-    nu = np.array(flatfreqs)
-    ufreqs = np.unique(nu)
-    # get domain of intrinsic image
-    ref_wcs, shape_out = find_optimal_celestial_wcs(list(zip(shapes, wcss, strict=False)), projection="SIN")
-    ref_wcs.array_shape = (shape_out[0], shape_out[1])
+def stitch_band(
+    apparent: np.ndarray,
+    beams: np.ndarray,
+    masks: np.ndarray,
+    mixed: np.ndarray | None = None,
+    rms: np.ndarray | None = None,
+    wsums: np.ndarray | None = None,
+    eta: float = 1e-3,
+) -> dict[str, np.ndarray]:
+    """Combine one band's partitions into the band-level products.
 
-    return ref_wcs, ufreqs, out_names
+    Args:
+        apparent: (npart, ncorr, ny, nx) apparent images, the partitions' BIMAGE.
+        beams: (npart, ncorr, ny, nx) primary beams.
+        masks: (npart, ny, nx) boolean footprints.
+        mixed: (npart, ncorr, ny, nx) partitions' KIMAGE, or None to skip it.
+        rms: (npart, ncorr) per-partition residual rms, or None to skip it.
+        wsums: (npart, ncorr) per-partition weight sums, or None to skip it.
+        eta: Tikhonov floor, keeping the solve finite where no partition covers.
 
+    Returns:
+        A dict with IMAGE, BEAM, BIMAGE and SPATIALWGT, plus KIMAGE, RMS and
+        WSUM when their inputs were supplied.
+    """
+    mask = masks[:, None, :, :]  # broadcast the footprint over correlations
+    weighted_beam = beams * mask
+    beam_sum = weighted_beam.sum(axis=0)
+    beam_sq = (weighted_beam**2).sum(axis=0)
+    rhs = (weighted_beam * apparent).sum(axis=0)
 
-@ray.remote
-def project(im, imnum, ref_wcs, beam, oname, method="interp"):
-    if method != "interp":
-        raise NotImplementedError("Only 'interp' method supported for now")
+    spatial = beam_sq + eta
+    with np.errstate(invalid="ignore", divide="ignore"):
+        image = np.where(spatial > 0, rhs / spatial, 0.0)
+        # beam-weighted mean response: reduces to B when the partitions agree,
+        # and to B_p where only partition p covers
+        beam = np.where(beam_sum > 0, beam_sq / beam_sum, 0.0)
+    image = np.nan_to_num(image, nan=0.0, posinf=0.0, neginf=0.0)
+    beam = np.nan_to_num(beam, nan=0.0, posinf=0.0, neginf=0.0)
 
-    # output shape
-    nxo, nyo = ref_wcs.array_shape
-
-    # interpolate beam
-    bds = xr.open_zarr(beam, chunks=None)
-    beam = bds.BEAM.values
-    l_beam = bds.l_beam.values
-    m_beam = bds.m_beam.values
-    bfreq = bds.chan.values
-
-    # make the power beam
-    pbeam = ((beam[0] * beam[0].conj()).real + (beam[-1] * beam[-1].conj()).real) / 2.0
-
-    # this is cheap, evaluation is more expensive
-    beamo = RegularGridInterpolator(
-        (bfreq, l_beam, m_beam),
-        pbeam,
-        bounds_error=False,
-        fill_value=None,
-        method="linear",
-    )
-
-    cell_x, cell_y = ref_wcs.wcs.cdelt
-    l_im = (-(nxo) // 2 + np.arange(nxo)) * cell_x
-    m_im = (-(nyo) // 2 + np.arange(nyo)) * cell_y
-    im_coords = {
-        "l": ("l", l_im),
-        "m": ("m", m_im),
+    out = {
+        "IMAGE": image,
+        "BEAM": beam,
+        "BIMAGE": beam * image,
+        "SPATIALWGT": spatial,
     }
-
-    image = fits.getdata(im)
-    ncorr, nchan, nx, ny = image.shape
-    hdr = fits.getheader(im)
-    freq, _ = data_from_header(hdr, axis=3)
-    wcs = WCS(hdr).dropaxis(-1).dropaxis(-1)
-    cxi, cyi = wcs.wcs.cdelt
-    nx, ny = wcs.array_shape
-    l = (-(nx) // 2 + np.arange(nx)) * cxi
-    m = (-(ny) // 2 + np.arange(ny)) * cyi
-    ll, mm = np.meshgrid(l, m, indexing="ij")
-
-    basename = oname.removesuffix(".fits")
-    # TODO - make these in parallel
-    for c in range(ncorr):
-        for f in range(nchan):
-            bdata = np.zeros((nx, ny), dtype=np.float64)
-            # freq is per-channel, so it is indexed by f. The reprojection of
-            # image[c, f] below uses both indices and shows the convention.
-            beami = beamo((freq[f], ll, mm))
-            step = 25
-            angles = np.linspace(0, 359, step)
-            for angle in angles:
-                bdata += ndimage.rotate(beami, angle, reshape=False, order=1, mode="nearest")
-            bdata /= angles.size
-            pbeam, footprint = reproject_interp(
-                (bdata, wcs),
-                ref_wcs,
-                shape_out=(nxo, nyo),
-                block_size="auto",
-                parallel=4,
-            )
-            mask = footprint > 0
-            pbeam[~mask] = 0
-            pdata, _ = reproject_interp(
-                (image[c, f], wcs),
-                ref_wcs,
-                shape_out=(nxo, nyo),
-                block_size="auto",
-                parallel=4,
-            )
-
-            im_attrs = {
-                "freq": freq[f],
-            }
-
-            data_vars = {
-                "IMAGE": (("l", "m"), pdata),
-                "BEAM": (("l", "m"), pbeam),
-                "MASK": (("l", "m"), mask),
-            }
-
-            ds = xr.Dataset(data_vars, coords=im_coords, attrs=im_attrs).chunk(
-                {
-                    "l": 512,
-                    "m": 512,
-                }
-            )
-
-            ds_name = f"{basename}_im{imnum}_pol{c}_ch{f}.zarr"
-            ds.to_zarr(ds_name, compute=True, mode="w", consolidated=False)
-
-    return imnum
-
-
-@ray.remote
-def stitch_images(freq, im_list, eta=1e-3):
-    # get all datasets in current plane
-    xds = []
-    for im in im_list:
-        ds = xr.open_zarr(im, chunks=None, consolidated=False)
-        if ds.freq == freq:
-            xds.append(ds)
-
-    # accumulate
-    nx = xds[0].l.size
-    ny = xds[0].m.size
-    y = np.zeros((nx, ny))
-    for ds in xds:
-        mask = ds.MASK.values
-        beam = ds.BEAM.values
-        image = ds.IMAGE.values
-        y[mask] += beam[mask] * image[mask]
-    ds = ds.drop_vars("IMAGE")
-
-    def hess(x):
-        out = np.zeros((nx, ny))
-        for ds in xds:
-            mask = ds.MASK.values
-            beam = ds.BEAM.values
-            res = beam**2 * x
-            out[mask] += res[mask]
-        return out + eta * x
-
-    image, info = conjugate_gradient(hess, y, max_iter=10)
-
-    weight = np.zeros((nx, ny))
-    for ds in xds:
-        mask = ds.MASK.values
-        beam = ds.BEAM.values
-        weight[mask] += beam[mask] ** 2
-    weight += eta
-    return image, weight, info, freq
+    if mixed is not None:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            km = np.where(beam_sum > 0, (weighted_beam * mixed).sum(axis=0) / beam_sum, 0.0)
+        out["KIMAGE"] = np.nan_to_num(km, nan=0.0, posinf=0.0, neginf=0.0)
+    if wsums is not None:
+        out["WSUM"] = np.asarray(wsums, dtype=np.float64).sum(axis=0)
+    if rms is not None:
+        # propagate through the same beam weighting the images went through, so
+        # spifit's threshold survives the mosaic. Weighted by each partition's
+        # peak response, which is the scalar analogue of the per-pixel weighting.
+        rms = np.asarray(rms, dtype=np.float64)
+        peak = np.array([np.nanmax(beams[p], axis=(-2, -1)) for p in range(beams.shape[0])])
+        denom = peak.sum(axis=0)
+        num = np.sqrt(((peak * rms) ** 2).sum(axis=0))
+        out["RMS"] = np.where(denom > 0, num / denom, 0.0)
+    return out
 
 
 def conjugate_gradient(A, b, x0=None, tol=1e-6, max_iter=100, report=20):
+    """Solve A x = b for a symmetric positive-definite operator A.
+
+    Retained for a future non-diagonal formulation; ``stitch_band`` solves the
+    current diagonal system directly.
+    """
     n = b.shape
     x = np.zeros(n) if x0 is None else x0.copy()
     r = A(x) - b
@@ -188,6 +97,7 @@ def conjugate_gradient(A, b, x0=None, tol=1e-6, max_iter=100, report=20):
     rs0 = rsold
     if rs0 < tol:
         return x, 0  # already at minimum
+    i = 0
     for i in range(max_iter):
         Ap = A(p)
         alpha = rsold / np.vdot(p, Ap)
@@ -203,6 +113,6 @@ def conjugate_gradient(A, b, x0=None, tol=1e-6, max_iter=100, report=20):
         rsold = rsnew
 
         if i % report == 0:
-            print(f"At {i} norm frac = {rsnew / rs0}")
+            log.debug("At %d norm frac = %s", i, rsnew / rs0)
 
     return x, i

--- a/src/spimple/utils/project.py
+++ b/src/spimple/utils/project.py
@@ -1,0 +1,86 @@
+"""The common output frame and the reprojection onto it.
+
+Every partition in a band must share one grid, as pfb's tree requires. This
+module resolves that grid from the input headers and moves each partition's
+(Y, X) arrays onto it.
+
+Arrays are (corr, y, x) throughout, which is also what reproject wants: for a
+2-axis celestial WCS, astropy binds arr[row, col] with col to WCS axis 1
+(RA-like) and row to WCS axis 2 (Dec-like).
+"""
+
+import numpy as np
+from astropy.wcs import WCS
+
+from spimple.utils.logging import get_logger
+
+log = get_logger("PROJECT")
+
+
+def union_wcs(headers: list) -> tuple[WCS, tuple[int, int]]:
+    """Resolve the smallest common frame covering every input.
+
+    Args:
+        headers: FITS headers, one per partition.
+
+    Returns:
+        The common WCS with array_shape set, and (ny, nx).
+    """
+    from reproject.mosaicking import find_optimal_celestial_wcs
+
+    inputs = []
+    for hdr in headers:
+        wcs = WCS(hdr).celestial
+        shape = (int(hdr["NAXIS2"]), int(hdr["NAXIS1"]))
+        inputs.append((shape, wcs))
+    wcs, shape_out = find_optimal_celestial_wcs(inputs, projection="SIN")
+    # find_optimal_celestial_wcs returns numpy (ny, nx)
+    shape = (int(shape_out[0]), int(shape_out[1]))
+    wcs.array_shape = shape
+    return wcs, shape
+
+
+def same_frame(wcs_a, shape_a: tuple[int, int], wcs_b, shape_b: tuple[int, int]) -> bool:
+    """Return True when reprojecting from one frame to the other is the identity.
+
+    Used to skip a near-identity reprojection for the single-pointing case,
+    which would otherwise resample the image for nothing.
+    """
+    if tuple(shape_a) != tuple(shape_b):
+        return False
+    return (
+        np.allclose(wcs_a.wcs.crval, wcs_b.wcs.crval, rtol=0.0, atol=1e-10)
+        and np.allclose(wcs_a.wcs.cdelt, wcs_b.wcs.cdelt, rtol=1e-12, atol=0.0)
+        and np.allclose(wcs_a.wcs.crpix, wcs_b.wcs.crpix, rtol=0.0, atol=1e-6)
+        and list(wcs_a.wcs.ctype) == list(wcs_b.wcs.ctype)
+    )
+
+
+def reproject_cube(cube: np.ndarray, ref_wcs, target_wcs, shape: tuple[int, int]) -> tuple[np.ndarray, np.ndarray]:
+    """Reproject a (ncorr, ny, nx) cube onto the target frame.
+
+    Args:
+        cube: (ncorr, ny, nx) on the reference frame.
+        ref_wcs: 2-axis celestial WCS describing cube.
+        target_wcs: 2-axis celestial WCS of the output.
+        shape: (ny, nx) of the output.
+
+    Returns:
+        The reprojected (ncorr, ny, nx) cube, zeroed outside the footprint, and
+        the (ny, nx) boolean footprint mask.
+    """
+    from reproject import reproject_interp
+
+    if same_frame(ref_wcs, cube.shape[-2:], target_wcs, shape):
+        return np.ascontiguousarray(cube), np.ones(shape, dtype=bool)
+
+    out = np.zeros((cube.shape[0], shape[0], shape[1]), dtype=np.float64)
+    mask = np.zeros(shape, dtype=bool)
+    for c in range(cube.shape[0]):
+        plane, footprint = reproject_interp((cube[c], ref_wcs), target_wcs, shape_out=shape)
+        covered = footprint > 0
+        plane = np.nan_to_num(plane, nan=0.0)
+        plane[~covered] = 0.0
+        out[c] = plane
+        mask |= covered
+    return out, mask

--- a/src/spimple/utils/render.py
+++ b/src/spimple/utils/render.py
@@ -1,0 +1,127 @@
+"""Render band-node variables from a DataTree store to FITS.
+
+The store's analogue of a FITS writer: it stacks a band variable across bands
+into a cube, forms the WSUM-weighted MFS reduction, and writes both with the
+store's own WCS. Everything is (corr, y, x) and goes out through
+``save_fits(yx_order=True)`` -- no transposes.
+"""
+
+import numpy as np
+import xarray as xr
+
+from spimple.utils.datatree import band_nodes, open_store, timeids
+from spimple.utils.fits import create_beams_table, save_fits, set_wcs
+from spimple.utils.logging import get_logger
+
+log = get_logger("RENDER")
+
+BPAR = ["BMAJ", "BMIN", "BPA"]
+
+
+def dt2fits(
+    store_url: str,
+    column: str,
+    outname: str,
+    unit: str = "Jy/beam",
+    otype=np.float32,
+    do_mfs: bool = True,
+    do_cube: bool = True,
+    timeid: int | None = None,
+    extra_hdr: dict | None = None,
+) -> list[str]:
+    """Write a band-node variable to FITS, as a cube and an MFS reduction.
+
+    Args:
+        store_url: Path to the store.
+        column: Band-node variable to render, e.g. "IMAGE".
+        outname: Output basename. Files are named
+            ``<outname>_<column>_time{t}.fits`` and ``..._mfs.fits``.
+        unit: BUNIT value.
+        otype: Output dtype.
+        do_mfs: Write the WSUM-weighted mean over bands.
+        do_cube: Write the per-band cube.
+        timeid: Restrict to one timeid; None renders every one.
+        extra_hdr: Extra header cards stamped into every file written.
+
+    Returns:
+        The paths written, in the order they were written.
+    """
+    basename = f"{outname}_{column.lower()}"
+    written: list[str] = []
+
+    dt = open_store(store_url)
+    wanted = timeids(dt) if timeid is None else [timeid]
+
+    for tid in wanted:
+        nodes = [n for n in band_nodes(dt, timeid=tid) if column in dt[n].ds]
+        if not nodes:
+            continue
+        datasets = [dt[n].ds for n in nodes]
+        ref = datasets[0]
+
+        cube = np.stack([ds[column].values for ds in datasets], axis=0)  # (band, corr, ny, nx)
+        wsums = np.stack([np.atleast_1d(ds.WSUM.values) for ds in datasets], axis=0)  # (band, corr)
+        wsum = wsums.sum(axis=0)
+        freqs = np.array([float(ds.attrs["freq_out"]) for ds in datasets])
+        nband, ncorr, ny, nx = cube.shape
+        cell_deg = np.rad2deg(float(ref.attrs["cell_rad"]))
+        radec = (float(ref.attrs["ra"]), float(ref.attrs["dec"]))
+        l0 = float(ref.attrs.get("l0", 0.0))
+        m0 = float(ref.attrs.get("m0", 0.0))
+        time_out = ref.attrs.get("time_out")
+
+        psfpars = None
+        beams_hdu = None
+        if all("PSFPARSF" in ds for ds in datasets):
+            pars = np.stack([ds.PSFPARSF.values for ds in datasets], axis=0)  # (band, corr, 3)
+            psfpars = pars[:, 0]  # FITS carries one beam per plane; use Stokes I
+            beams_hdu = create_beams_table(
+                xr.DataArray(
+                    pars,
+                    dims=("band", "corr", "bpar"),
+                    coords={"band": np.arange(nband), "corr": list(ref.corr.values), "bpar": BPAR},
+                ),
+                cell2deg=cell_deg,
+            )
+
+        def _header(freq, gausspars, psfpars=psfpars):
+            hdr = set_wcs(
+                cell_deg,
+                cell_deg,
+                nx,
+                ny,
+                radec,
+                freq,
+                unit=unit,
+                gausspar=None if psfpars is None else psfpars[0],
+                gausspars=gausspars,
+                ms_time=time_out,
+                time_is_unix=True,
+                l0=l0,
+                m0=m0,
+            )
+            for key, value in (extra_hdr or {}).items():
+                hdr[key] = value
+            return hdr
+
+        if do_mfs:
+            with np.errstate(invalid="ignore", divide="ignore"):
+                mfs = np.sum(cube * wsums[:, :, None, None], axis=0) / wsum[:, None, None]
+            freq_mfs = float(np.sum(freqs[:, None] * wsums) / wsum.sum())
+            hdr = _header(freq_mfs, None)
+            hdr["WSUM"] = float(wsum[0])
+            name = f"{basename}_time{tid}_mfs.fits"
+            save_fits(name, mfs[None], hdr, dtype=otype, yx_order=True)
+            written.append(name)
+            log.info("Wrote %s", name)
+
+        if do_cube:
+            hdr = _header(freqs, psfpars)
+            for band in range(nband):
+                hdr[f"WSUM{band + 1}"] = float(wsums[band, 0])
+            name = f"{basename}_time{tid}.fits"
+            save_fits(name, cube, hdr, dtype=otype, beams_hdu=beams_hdu, yx_order=True)
+            written.append(name)
+            log.info("Wrote %s", name)
+
+    return written

--- a/src/spimple/utils/restoration.py
+++ b/src/spimple/utils/restoration.py
@@ -1,0 +1,81 @@
+"""Restoration arithmetic for one image grid.
+
+Pure array functions -- no tree I/O, no FITS, no Ray. ``core/init.py`` owns
+reading the FITS and writing the store.
+
+Flux scales (see the pfb wiki's D22/D23): the model is intrinsic flux while the
+residual is apparent, so a restored image must say which scale it is on. Three
+are offered, keyed by their CLI letter and named as pfb's restore names them.
+"""
+
+import numpy as np
+
+from spimple.utils.convolution import convolve2gaussres
+
+
+def restore_products(
+    model: np.ndarray,
+    residual: np.ndarray,
+    beam: np.ndarray,
+    gaussparf: np.ndarray,
+    gausspari: np.ndarray | None = None,
+    products: tuple[str, ...] = ("k",),
+    pb_min: float = 0.1,
+    nthreads: int = 1,
+    padding_frac: float = 0.5,
+) -> dict[str, np.ndarray]:
+    """Build the restored images for one image grid.
+
+    Args:
+        model: (ncorr, ny, nx) intrinsic model in Jy/pixel. Pass zeros when the
+            input is a restored image rather than a model.
+        residual: (ncorr, ny, nx) apparent residual already in Jy/beam.
+        beam: (ncorr, ny, nx) primary beam response.
+        gaussparf: (ncorr, 3) target resolution in pixels, pixels, radians.
+        gausspari: (ncorr, 3) intrinsic resolution of the residual, or None to
+            skip the reconvolution. None is correct whenever gaussparf already
+            is the residual's own resolution.
+        products: Any of "a" (apparent), "i" (intrinsic) and "k" (intrinsic
+            model plus apparent residual).
+        pb_min: Beam floor below which the intrinsic image is zeroed.
+        nthreads: Threads for the convolution FFTs.
+        padding_frac: FFT padding fraction.
+
+    Returns:
+        A dict mapping each requested key to an (ncorr, ny, nx) array.
+    """
+    model = np.asarray(model)
+    residual = np.asarray(residual)
+    beam = np.asarray(beam)
+    gaussparf = np.asarray(gaussparf, dtype=float)
+    if not products:
+        return {}
+
+    _, ny, nx = model.shape
+    # grids stay x-major; yx_order transposes the (corr, y, x) images onto them
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+    kw = {"nthreads": nthreads, "pfrac": padding_frac, "norm_kernel": False, "yx_order": True}
+
+    if gausspari is None or np.allclose(gaussparf, np.asarray(gausspari, dtype=float)):
+        rconv = residual
+    else:
+        rconv, _ = convolve2gaussres(residual, xx, yy, gaussparf, gausspari=np.asarray(gausspari, dtype=float), **kw)
+
+    out: dict[str, np.ndarray] = {}
+    if "i" in products or "k" in products:
+        # the model carries no intrinsic resolution -- the clean-component assumption
+        mconv, _ = convolve2gaussres(model, xx, yy, gaussparf, **kw)
+    if "k" in products:
+        out["k"] = np.ascontiguousarray(mconv + rconv)
+    if "i" in products:
+        with np.errstate(invalid="ignore", divide="ignore"):
+            rint = np.where(beam > pb_min, rconv / beam, 0.0)
+        out["i"] = np.ascontiguousarray(np.where(beam > pb_min, mconv + rint, 0.0))
+    if "a" in products:
+        # (B*m) convolved, NOT B*(m convolved): convolution does not commute
+        # with multiplication by a spatially varying beam, so mconv cannot be reused
+        aconv, _ = convolve2gaussres(beam * model, xx, yy, gaussparf, **kw)
+        out["a"] = np.ascontiguousarray(aconv + rconv)
+    return out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,3 +240,49 @@ def pfb_tree(tmp_path_factory):
             {"corr": ["I"]},
         )
     return url
+
+
+def _beam_fits(path, freqs, sigma_l_deg, sigma_m_deg, npix=48, cell_deg=None):
+    """A Gaussian power beam on its own coarse grid, centred on the pointing."""
+    cell_deg = cell_deg if cell_deg is not None else 20.0 / 3600.0
+    hdr = fits.Header()
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CRVAL1"] = 30.0
+    hdr["CRPIX1"] = npix // 2 + 1
+    hdr["CDELT1"] = -cell_deg
+    hdr["CUNIT1"] = "deg"
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CRVAL2"] = -30.0
+    hdr["CRPIX2"] = npix // 2 + 1
+    hdr["CDELT2"] = cell_deg
+    hdr["CUNIT2"] = "deg"
+    hdr["CTYPE4"] = "FREQ"
+    hdr["CRVAL4"] = float(freqs[0])
+    hdr["CRPIX4"] = 1
+    hdr["CDELT4"] = float(freqs[1] - freqs[0]) if len(freqs) > 1 else 1.0e8
+    hdr["CUNIT4"] = "Hz"
+    hdr["CTYPE3"] = "STOKES"
+    hdr["CRVAL3"] = 1.0
+    hdr["CRPIX3"] = 1
+    hdr["CDELT3"] = 1.0
+
+    v = (np.arange(npix) - npix // 2) * cell_deg
+    ll, mm = np.meshgrid(-v, v)  # (ny, nx); l descends with x, m ascends with y
+    plane = np.exp(-0.5 * (ll**2 / sigma_l_deg**2 + mm**2 / sigma_m_deg**2))
+    data = np.repeat(plane[None, None], len(freqs), axis=0).astype(np.float32)
+    fits.writeto(path, data, hdr, overwrite=True)
+    return str(path)
+
+
+@pytest.fixture(scope="session")
+def fits_beam_cube(tmp_path_factory):
+    """A circular Gaussian power beam on a coarser grid than the image."""
+    path = tmp_path_factory.mktemp("beam") / "beam.fits"
+    return _beam_fits(path, [1.0e9, 1.1e9], 0.05, 0.05)
+
+
+@pytest.fixture(scope="session")
+def fits_beam_cube_elliptical(tmp_path_factory):
+    """Elongated along m, so a transposed read is detectable."""
+    path = tmp_path_factory.mktemp("beam") / "beam_ell.fits"
+    return _beam_fits(path, [1.0e9], 0.02, 0.06)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,3 +286,27 @@ def fits_beam_cube_elliptical(tmp_path_factory):
     """Elongated along m, so a transposed read is detectable."""
     path = tmp_path_factory.mktemp("beam") / "beam_ell.fits"
     return _beam_fits(path, [1.0e9], 0.02, 0.06)
+
+
+@pytest.fixture(scope="session")
+def two_pointing_fits(tmp_path_factory):
+    """Two overlapping pointings sharing a channelisation.
+
+    Returns (model_paths, residual_paths). The pointings are offset in RA by a
+    quarter of the image, so they overlap over most of their area.
+    """
+    folder = tmp_path_factory.mktemp("pointings")
+    offsets = [0.0, NPIX // 4 * CELL_DEG]
+    models, residuals = [], []
+    rng = np.random.default_rng(21)
+    for pid, offset in enumerate(offsets):
+        for name, cube, out in (
+            ("model", _power_law_cube(TRUE_ALPHA, seed=42), models),
+            ("residual", rng.normal(scale=1e-3, size=(NCHAN, NPIX, NPIX)), residuals),
+        ):
+            hdr = _add_per_channel_beams(_base_header(freq_axis=4))
+            hdr["CRVAL1"] = 30.0 + offset
+            hdr["WSCVWSUM"] = 1.0 + pid
+            path = folder / f"field{pid}-{name}.fits"
+            out.append(_write(path, _shape_for(np.asarray(cube, dtype=np.float32), 4), hdr))
+    return models, residuals

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,3 +141,102 @@ def residual_cube(tmp_path_factory):
     rng = np.random.default_rng(7)
     noise = rng.normal(scale=1e-3, size=(NCHAN, NPIX, NPIX)).astype(np.float32)
     return _write(path, _shape_for(noise, 4), hdr)
+
+
+NBAND_TREE = 4
+NCORR_TREE = 1
+CELL_RAD = np.deg2rad(CELL_DEG)
+BPAR = ["BMAJ", "BMIN", "BPA"]
+
+
+def _tree_beam(npix: int) -> np.ndarray:
+    """A smooth, circularly symmetric response peaking at 1.0 in the centre."""
+    v = np.arange(npix) - npix // 2
+    yy, xx = np.meshgrid(v, v, indexing="ij")
+    return np.exp(-(xx**2 + yy**2) / (2 * (npix / 2.5) ** 2))
+
+
+@pytest.fixture(scope="session")
+def pfb_tree(tmp_path_factory):
+    """A synthetic pfb-shaped DataTree, homogenised, with spectral index TRUE_ALPHA.
+
+    Built to the layout documented in pfb-imaging's docs/wiki/imager-pipeline.md
+    (verified against pfb-imaging commit b84407b, branch dev-0.1.0). If that page
+    changes, this fixture must be re-checked -- it is the only thing standing
+    between spimple's consumers and the real contract.
+
+    Everything is (corr, y, x). PSFPARSN and PSFPARSF are in pixels and radians.
+    """
+    from spimple.utils.datatree import band_node_name, create_store, partition_node_name, write_node
+
+    url = str(tmp_path_factory.mktemp("tree") / "synth_I.dt")
+    freqs = frequencies()
+    beam = _tree_beam(NPIX)[None]  # (ncorr, ny, nx)
+    cube = _power_law_cube(TRUE_ALPHA, seed=11)  # (nband, ny, nx), intrinsic
+    rng = np.random.default_rng(3)
+    # homogenised: every band already sits at the same resolution
+    psfparsf = np.tile([8.0, 6.4, 0.0], (NCORR_TREE, 1))
+
+    create_store(
+        url,
+        {
+            "spimple_version": "test",
+            "product": "I",
+            "nband": NBAND_TREE,
+            "ntime": 1,
+            "nx": NPIX,
+            "ny": NPIX,
+            "cell_rad": CELL_RAD,
+        },
+        overwrite=True,
+    )
+
+    for band in range(NBAND_TREE):
+        intrinsic = cube[band][None].astype(np.float32)
+        apparent = (intrinsic * beam).astype(np.float32)
+        residual = rng.normal(scale=1e-3, size=intrinsic.shape).astype(np.float32)
+        wsum = np.array([1.0 + band], dtype=np.float32)
+        node = band_node_name(band, 0)
+        write_node(
+            url,
+            node,
+            {
+                "MODEL": (("corr", "y", "x"), intrinsic),
+                "RESIDUAL": (("corr", "y", "x"), (residual * wsum[:, None, None]).astype(np.float32)),
+                "IMAGE": (("corr", "y", "x"), intrinsic),
+                "BIMAGE": (("corr", "y", "x"), apparent),
+                "KIMAGE": (("corr", "y", "x"), (apparent + residual).astype(np.float32)),
+                "BEAM": (("corr", "y", "x"), beam.astype(np.float32)),
+                "WSUM": (("corr",), wsum),
+                "PSFPARSN": (("corr", "bpar"), psfparsf.astype(np.float32)),
+                "PSFPARSF": (("corr", "bpar"), psfparsf.astype(np.float32)),
+            },
+            {
+                "bandid": band,
+                "timeid": 0,
+                "freq_out": float(freqs[band]),
+                "freq_nominal": float(freqs[band]),
+                "time_out": 1.0e9,
+                "ra": np.deg2rad(30.0),
+                "dec": np.deg2rad(-30.0),
+                "cell_rad": CELL_RAD,
+                "l0": 0.0,
+                "m0": 0.0,
+                "pb_min": 0.15,
+            },
+            {"corr": ["I"], "bpar": BPAR},
+        )
+        write_node(
+            url,
+            f"{node}/{partition_node_name(0)}",
+            {"BEAM": (("corr", "y", "x"), beam.astype(np.float32))},
+            {
+                "field_name": "synth",
+                "ra0": np.deg2rad(30.0),
+                "dec0": np.deg2rad(-30.0),
+                "freq_out": float(freqs[band]),
+                "beam_includes_n": True,
+            },
+            {"corr": ["I"]},
+        )
+    return url

--- a/tests/test_beamsource.py
+++ b/tests/test_beamsource.py
@@ -1,0 +1,112 @@
+"""The primary-beam backends init can attach to a partition."""
+
+import numpy as np
+import pytest
+from astropy.wcs import WCS
+
+from spimple.utils.beamsource import beam_for_grid, lm_grid
+
+CELL_DEG = 10.0 / 3600.0
+NY, NX = 20, 28
+
+
+def _wcs(cell_deg=CELL_DEG):
+    w = WCS(naxis=2)
+    w.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    w.wcs.cdelt = [-cell_deg, cell_deg]
+    w.wcs.crpix = [1 + NX // 2, 1 + NY // 2]
+    w.wcs.crval = [30.0, -30.0]
+    w.array_shape = (NY, NX)
+    return w
+
+
+def _wide_wcs():
+    """A grid spanning about a degree, comparable to MeerKAT's L-band beam.
+
+    On the 10-arcsecond grid the analytic beam varies by only 0.3 percent across
+    the whole image, so its argmax is numerical noise rather than the pointing.
+    """
+    return _wcs(cell_deg=200.0 / 3600.0)
+
+
+def test_lm_grid_has_the_yx_raster_and_the_right_signs():
+    ll, mm = lm_grid(_wcs(), (NY, NX))
+
+    assert ll.shape == (NY, NX)
+    assert mm.shape == (NY, NX)
+    # l runs along x and decreases, m runs along y and increases
+    assert ll[0, 0] > ll[0, -1]
+    assert mm[0, 0] < mm[-1, 0]
+    # the reference pixel sits at the origin
+    assert ll[NY // 2, NX // 2] == pytest.approx(0.0)
+    assert mm[NY // 2, NX // 2] == pytest.approx(0.0)
+
+
+def test_no_beam_model_returns_ones():
+    freqs = np.array([1.0e9, 1.1e9])
+
+    beam = beam_for_grid(None, "L", freqs, _wcs(), (NY, NX), ncorr=1)
+
+    assert beam.shape == (2, 1, NY, NX)
+    np.testing.assert_allclose(beam, 1.0)
+
+
+def test_jimbeam_peaks_at_the_pointing_centre_and_falls_off():
+    pytest.importorskip("katbeam")
+    freqs = np.array([1.0e9])
+
+    beam = beam_for_grid("JimBeam", "L", freqs, _wide_wcs(), (NY, NX), ncorr=1)
+
+    assert beam.shape == (1, 1, NY, NX)
+    peak = np.unravel_index(np.argmax(beam[0, 0]), (NY, NX))
+    assert peak == (NY // 2, NX // 2)
+    assert beam[0, 0, 0, 0] < beam[0, 0, NY // 2, NX // 2]
+
+
+def test_jimbeam_broadcasts_over_correlations():
+    pytest.importorskip("katbeam")
+    freqs = np.array([1.0e9])
+
+    beam = beam_for_grid("JimBeam", "L", freqs, _wide_wcs(), (NY, NX), ncorr=2)
+
+    assert beam.shape == (1, 2, NY, NX)
+    np.testing.assert_allclose(beam[0, 0], beam[0, 1])
+
+
+def test_jimbeam_rejects_an_unknown_band():
+    pytest.importorskip("katbeam")
+
+    with pytest.raises(ValueError, match="band"):
+        beam_for_grid("JimBeam", "P", np.array([1.0e9]), _wide_wcs(), (NY, NX), ncorr=1)
+
+
+def test_a_fits_beam_is_reprojected_onto_the_target_grid(fits_beam_cube):
+    """A beam cube on a coarser grid must land on the image grid, peak in the centre."""
+    freqs = np.array([1.0e9, 1.1e9])
+
+    beam = beam_for_grid(fits_beam_cube, "L", freqs, _wcs(), (NY, NX), ncorr=1)
+
+    assert beam.shape == (2, 1, NY, NX)
+    peak = np.unravel_index(np.argmax(beam[0, 0]), (NY, NX))
+    assert peak == (NY // 2, NX // 2)
+    assert beam[0, 0].max() == pytest.approx(1.0, abs=2e-2)
+
+
+def test_a_fits_beam_is_not_transposed(fits_beam_cube_elliptical):
+    """An elliptical beam catches a transpose that a circular one hides."""
+    freqs = np.array([1.0e9])
+
+    beam = beam_for_grid(fits_beam_cube_elliptical, "L", freqs, _wcs(), (NY, NX), ncorr=1)
+
+    plane = beam[0, 0]
+    # the fixture is elongated along m (the y axis), so the half-power extent
+    # measured along y must exceed the extent along x
+    above = plane > 0.5 * plane.max()
+    extent_y = above[:, NX // 2].sum()
+    extent_x = above[NY // 2, :].sum()
+    assert extent_y > extent_x
+
+
+def test_an_unknown_beam_model_is_rejected():
+    with pytest.raises(ValueError, match="Unknown beam model"):
+        beam_for_grid("/no/such/thing.txt", "L", np.array([1.0e9]), _wcs(), (NY, NX), ncorr=1)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -5,7 +5,7 @@ from typer.testing import CliRunner
 
 from spimple.cli import app
 
-COMMANDS = ["spifit", "imconv", "binterp", "mosaic"]
+COMMANDS = ["init", "spifit", "imconv", "binterp", "mosaic"]
 
 runner = CliRunner()
 
@@ -21,3 +21,14 @@ def test_group_help():
 def test_command_help(command):
     result = runner.invoke(app, [command, "--help"])
     assert result.exit_code == 0
+
+
+def test_init_help_lists_the_key_options(monkeypatch):
+    # rich truncates option names to the terminal width, so widen it or
+    # --output-filename renders as --output-filen...
+    monkeypatch.setenv("COLUMNS", "200")
+    result = runner.invoke(app, ["init", "--help"])
+
+    assert result.exit_code == 0
+    for flag in ("--images", "--output-filename", "--psf-pars", "--beam-model", "--nworkers"):
+        assert flag in result.stdout

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -32,3 +32,13 @@ def test_init_help_lists_the_key_options(monkeypatch):
     assert result.exit_code == 0
     for flag in ("--images", "--output-filename", "--psf-pars", "--beam-model", "--nworkers"):
         assert flag in result.stdout
+
+
+def test_spifit_help_shows_the_store_and_flux_scale_options(monkeypatch):
+    monkeypatch.setenv("COLUMNS", "200")
+    result = runner.invoke(app, ["spifit", "--help"])
+
+    assert result.exit_code == 0
+    assert "--store" in result.stdout
+    assert "--flux-scale" in result.stdout
+    assert "--beam-model" not in result.stdout

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,9 +1,25 @@
 """Every command must at least be reachable and describe itself."""
 
+import re
+
 import pytest
 from typer.testing import CliRunner
 
 from spimple.cli import app
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(text: str) -> str:
+    """Strip ANSI styling from help output.
+
+    rich styles each option name as several spans, so a coloured
+    "--images" contains no literal "--images" substring. Colour is on in
+    CI and off in a plain local run, which is exactly the kind of
+    difference that passes locally and fails on the runner.
+    """
+    return _ANSI.sub("", text)
+
 
 COMMANDS = ["init", "spifit", "imconv", "binterp", "mosaic"]
 
@@ -30,8 +46,9 @@ def test_init_help_lists_the_key_options(monkeypatch):
     result = runner.invoke(app, ["init", "--help"])
 
     assert result.exit_code == 0
+    out = plain(result.stdout)
     for flag in ("--images", "--output-filename", "--psf-pars", "--beam-model", "--nworkers"):
-        assert flag in result.stdout
+        assert flag in out
 
 
 def test_spifit_help_shows_the_store_and_flux_scale_options(monkeypatch):
@@ -39,6 +56,7 @@ def test_spifit_help_shows_the_store_and_flux_scale_options(monkeypatch):
     result = runner.invoke(app, ["spifit", "--help"])
 
     assert result.exit_code == 0
-    assert "--store" in result.stdout
-    assert "--flux-scale" in result.stdout
-    assert "--beam-model" not in result.stdout
+    out = plain(result.stdout)
+    assert "--store" in out
+    assert "--flux-scale" in out
+    assert "--beam-model" not in out

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -121,3 +121,18 @@ def test_convolve2gaussres_rejects_a_mismatched_per_plane_target():
 
     with pytest.raises(ValueError, match="gaussparf"):
         convolve2gaussres(image, xx, yy, targets, 1)
+
+
+def test_convolve2gaussres_accepts_a_numpy_gausspari():
+    """gausspari as an array must not trip an elementwise truth test."""
+    nx, ny = 48, 48
+    xx, yy = _grids(nx, ny)
+    image = np.zeros((2, nx, ny))
+    image[:, nx // 2, ny // 2] = 1.0
+    gausspari = np.array([[4.0, 4.0, 0.0], [4.0, 4.0, 0.0]])
+    gaussparf = np.array([[8.0, 8.0, 0.0], [8.0, 8.0, 0.0]])
+
+    out, _ = convolve2gaussres(image, xx, yy, gaussparf, 1, gausspari=gausspari)
+
+    assert np.isfinite(out).all()
+    assert out[0, nx // 2, ny // 2] > 0.0

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -40,3 +40,37 @@ def test_convolve2gaussres(nx, ny, nband, alpha):
     # offset for relative difference
     assert_allclose(1 + alpha, 1 + out[0, :], atol=5e-4, rtol=5e-4)
     assert_allclose(out[2, :], restored[0, Ix, Iy], atol=5e-4, rtol=5e-4)
+
+
+def test_gaussian2d_has_the_requested_fwhm():
+    """Half maximum falls at emaj/2 along y and emin/2 along x when pa is zero.
+
+    The quadratic form puts the major axis along y at pa = 0, matching the FITS
+    convention where BPA is measured from north.
+    """
+    n = 129
+    c = n // 2
+    v = np.arange(n) - c
+    xx, yy = np.meshgrid(v, v, indexing="ij")
+
+    kern = Gaussian2D(xx, yy, (20.0, 10.0, 0.0), normalise=False, nsigma=10)
+
+    assert kern[c, c] == pytest.approx(1.0)
+    assert kern[c, c + 10] == pytest.approx(0.5, rel=1e-12)
+    assert kern[c + 5, c] == pytest.approx(0.5, rel=1e-12)
+
+
+def test_gaussian2d_support_is_nsigma_standard_deviations():
+    """The kernel is truncated at nsigma sigma, not nsigma FWHM."""
+    n = 257
+    c = n // 2
+    v = np.arange(n) - c
+    xx, yy = np.meshgrid(v, v, indexing="ij")
+
+    kern = Gaussian2D(xx, yy, (20.0, 20.0, 0.0), normalise=False, nsigma=5)
+
+    sigma = 20.0 / (2 * np.sqrt(2 * np.log(2)))
+    inside = int(4.0 * sigma)
+    outside = int(6.0 * sigma)
+    assert kern[c + inside, c] > 0.0
+    assert kern[c + outside, c] == 0.0

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -60,20 +60,23 @@ def test_gaussian2d_has_the_requested_fwhm():
     assert kern[c + 5, c] == pytest.approx(0.5, rel=1e-12)
 
 
-def test_gaussian2d_support_is_nsigma_standard_deviations():
-    """The kernel is truncated at nsigma sigma, not nsigma FWHM."""
-    n = 257
+def test_gaussian2d_support_is_nsigma_major_axis_fwhms():
+    """Support is nsigma FWHMs, wide enough that deconvolution stays clean.
+
+    Truncating nearer the core leaves a spectral ripple that swamps the
+    kernel's own transform when convolve2gaussres divides by it; see the
+    comment in Gaussian2D and the deconvolution test below.
+    """
+    n = 513
     c = n // 2
     v = np.arange(n) - c
     xx, yy = np.meshgrid(v, v, indexing="ij")
 
-    kern = Gaussian2D(xx, yy, (20.0, 20.0, 0.0), normalise=False, nsigma=5)
+    emaj = 20.0
+    kern = Gaussian2D(xx, yy, (emaj, emaj, 0.0), normalise=False, nsigma=5)
 
-    sigma = 20.0 / (2 * np.sqrt(2 * np.log(2)))
-    inside = int(4.0 * sigma)
-    outside = int(6.0 * sigma)
-    assert kern[c + inside, c] > 0.0
-    assert kern[c + outside, c] == 0.0
+    assert kern[c + int(4.5 * emaj), c] > 0.0
+    assert kern[c + int(5.5 * emaj), c] == 0.0
 
 
 def _grids(nx, ny):
@@ -136,3 +139,36 @@ def test_convolve2gaussres_accepts_a_numpy_gausspari():
 
     assert np.isfinite(out).all()
     assert out[0, nx // 2, ny // 2] > 0.0
+
+
+@pmp("npix", [32, 128])
+def test_convolve2gaussres_preserves_position_when_deconvolving(npix):
+    """Deconvolving from gausspari to gaussparf must not move a source.
+
+    This is the path init uses to homogenise resolution. It is sensitive to
+    the Gaussian kernel's support: truncating the kernel too near its core
+    makes the division by its transform ring badly enough to displace the
+    peak by twice its offset from the image centre.
+    """
+    y0, x0 = npix // 3, npix // 2 + 4
+    image = np.zeros((1, npix, npix))
+    image[0, y0, x0] = 1.0
+    v = -(npix // 2) + np.arange(npix)
+    xx, yy = np.meshgrid(v, v, indexing="ij")
+
+    out, _ = convolve2gaussres(
+        image,
+        xx,
+        yy,
+        np.array([[6.3, 4.2, 0.0]]),
+        1,
+        gausspari=np.array([[6.0, 4.0, 0.0]]),
+        yx_order=True,
+    )
+
+    assert np.unravel_index(np.argmax(out[0]), out[0].shape) == (y0, x0)
+    if npix >= 128:
+        # Ringing is only meaningfully bounded once the beam is small relative
+        # to the image. At npix=32 a 6-pixel beam spans a fifth of the frame and
+        # large ringing is physical, not a defect.
+        assert abs(out[0].min()) < 0.1 * out[0].max()

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -74,3 +74,50 @@ def test_gaussian2d_support_is_nsigma_standard_deviations():
     outside = int(6.0 * sigma)
     assert kern[c + inside, c] > 0.0
     assert kern[c + outside, c] == 0.0
+
+
+def _grids(nx, ny):
+    x = -(nx // 2) + np.arange(nx)
+    y = -(ny // 2) + np.arange(ny)
+    return np.meshgrid(x, y, indexing="ij")
+
+
+def test_convolve2gaussres_yx_order_matches_the_transposed_call():
+    """Convolving (n, y, x) with yx_order equals convolving its transpose without."""
+    nx, ny, nband = 48, 32, 3
+    xx, yy = _grids(nx, ny)
+    rng = np.random.default_rng(7)
+    xmajor = rng.normal(size=(nband, nx, ny))
+    yxmajor = xmajor.transpose(0, 2, 1).copy()
+    target = (6.0, 4.0, 0.4)
+
+    ref, ref_kern = convolve2gaussres(xmajor, xx, yy, target, 1)
+    out, out_kern = convolve2gaussres(yxmajor, xx, yy, target, 1, yx_order=True)
+
+    np.testing.assert_allclose(out, ref.transpose(0, 2, 1), atol=1e-12)
+    np.testing.assert_allclose(out_kern, ref_kern.transpose(0, 2, 1), atol=1e-12)
+
+
+def test_convolve2gaussres_accepts_a_target_per_plane():
+    """A (nplane, 3) gaussparf convolves each plane to its own resolution."""
+    nx, ny = 64, 64
+    xx, yy = _grids(nx, ny)
+    delta = np.zeros((2, nx, ny))
+    delta[:, nx // 2, ny // 2] = 1.0
+    targets = np.array([[8.0, 8.0, 0.0], [4.0, 4.0, 0.0]])
+
+    out, _ = convolve2gaussres(delta, xx, yy, targets, 1, norm_kernel=False)
+
+    for plane in range(targets.shape[0]):
+        expected = Gaussian2D(xx, yy, tuple(targets[plane]), normalise=False)
+        np.testing.assert_allclose(out[plane], expected, atol=1e-8)
+
+
+def test_convolve2gaussres_rejects_a_mismatched_per_plane_target():
+    nx, ny = 32, 32
+    xx, yy = _grids(nx, ny)
+    image = np.zeros((3, nx, ny))
+    targets = np.array([[8.0, 8.0, 0.0], [4.0, 4.0, 0.0]])
+
+    with pytest.raises(ValueError, match="gaussparf"):
+        convolve2gaussres(image, xx, yy, targets, 1)

--- a/tests/test_datatree.py
+++ b/tests/test_datatree.py
@@ -1,0 +1,147 @@
+"""The DataTree schema layer.
+
+These tests pin the cross-repo contract described in the design spec section 3.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+from astropy.io import fits
+
+from spimple.utils.datatree import (
+    PRODUCT_VARS,
+    band_node_name,
+    band_nodes,
+    check_homogeneous,
+    create_store,
+    open_store,
+    partition_node_name,
+    partition_nodes,
+    psfpars_from_header,
+    require_vars,
+    timeids,
+    write_node,
+)
+
+BPAR = ["BMAJ", "BMIN", "BPA"]
+
+
+def test_node_names_are_zero_padded_to_four_digits():
+    assert band_node_name(0, 0) == "band0000_time0000"
+    assert band_node_name(12, 3) == "band0012_time0003"
+    assert partition_node_name(7) == "part0007"
+
+
+def test_band_nodes_are_ordered_by_bandid_not_by_frequency(tmp_path):
+    """Effective frequencies are data-dependent and can invert; bandid cannot."""
+    url = str(tmp_path / "out.dt")
+    create_store(url, {"product": "I"}, overwrite=True)
+    # band 0 deliberately carries the HIGHER freq_out
+    write_node(url, band_node_name(0, 0), {}, {"bandid": 0, "timeid": 0, "freq_out": 2.0e9}, {})
+    write_node(url, band_node_name(1, 0), {}, {"bandid": 1, "timeid": 0, "freq_out": 1.0e9}, {})
+
+    dt = open_store(url)
+    assert band_nodes(dt) == ["band0000_time0000", "band0001_time0000"]
+
+
+def test_band_nodes_filter_by_timeid(tmp_path):
+    url = str(tmp_path / "out.dt")
+    create_store(url, {"product": "I"}, overwrite=True)
+    write_node(url, band_node_name(0, 0), {}, {"bandid": 0, "timeid": 0}, {})
+    write_node(url, band_node_name(0, 1), {}, {"bandid": 0, "timeid": 1}, {})
+
+    dt = open_store(url)
+    assert timeids(dt) == [0, 1]
+    assert band_nodes(dt, timeid=1) == ["band0000_time0001"]
+
+
+def test_partition_nodes_are_ordered_and_scoped_to_their_band(tmp_path):
+    url = str(tmp_path / "out.dt")
+    create_store(url, {"product": "I"}, overwrite=True)
+    node = band_node_name(0, 0)
+    write_node(url, node, {}, {"bandid": 0, "timeid": 0}, {})
+    for pid in (1, 0):
+        write_node(url, f"{node}/{partition_node_name(pid)}", {}, {"field_name": f"f{pid}"}, {})
+
+    dt = open_store(url)
+    assert partition_nodes(dt, node) == ["part0000", "part0001"]
+
+
+def test_write_node_preserves_existing_attrs(tmp_path):
+    """to_zarr(mode='a') replaces attrs wholesale; write_node must merge."""
+    url = str(tmp_path / "out.dt")
+    create_store(url, {"product": "I"}, overwrite=True)
+    node = band_node_name(0, 0)
+    write_node(url, node, {"WSUM": (("corr",), np.ones(1))}, {"bandid": 0, "timeid": 0}, {"corr": ["I"]})
+    write_node(url, node, {"IMAGE": (("corr", "y", "x"), np.zeros((1, 4, 4)))}, {"pb_min": 0.15}, {"corr": ["I"]})
+
+    ds = open_store(url)[node].ds
+    assert ds.attrs["bandid"] == 0
+    assert ds.attrs["pb_min"] == 0.15
+    assert "WSUM" in ds and "IMAGE" in ds
+
+
+def test_require_vars_names_the_fix_in_its_error():
+    ds = xr.Dataset({"IMAGE": (("y", "x"), np.zeros((2, 2)))})
+
+    with pytest.raises(ValueError, match="spimple mosaic"):
+        require_vars(ds, ["IMAGE", "BEAM"], "band0000_time0000", "run spimple mosaic")
+
+
+def test_check_homogeneous_accepts_equal_psfparsf_and_returns_it():
+    pars = np.array([[8.0, 6.0, 0.3]])
+    nodes = [xr.Dataset({"PSFPARSF": (("corr", "bpar"), pars.copy())}) for _ in range(3)]
+
+    out = check_homogeneous(nodes)
+
+    np.testing.assert_allclose(out, pars)
+
+
+def test_check_homogeneous_rejects_differing_psfparsf():
+    a = xr.Dataset({"PSFPARSF": (("corr", "bpar"), np.array([[8.0, 6.0, 0.3]]))})
+    b = xr.Dataset({"PSFPARSF": (("corr", "bpar"), np.array([[7.0, 6.0, 0.3]]))})
+
+    with pytest.raises(ValueError, match="pfb restore"):
+        check_homogeneous([a, b])
+
+
+def test_check_homogeneous_rejects_a_missing_psfparsf():
+    with pytest.raises(ValueError, match="PSFPARSF"):
+        check_homogeneous([xr.Dataset({"IMAGE": (("y", "x"), np.zeros((2, 2)))})])
+
+
+def test_psfpars_from_header_converts_degrees_to_pixels_and_radians():
+    cell_deg = 1 / 3600
+    hdr = fits.Header()
+    for i in (1, 2):
+        hdr[f"BMAJ{i}"] = 8.0 * cell_deg * i
+        hdr[f"BMIN{i}"] = 6.0 * cell_deg * i
+        hdr[f"BPA{i}"] = 30.0
+
+    pars = psfpars_from_header(hdr, nband=2, ncorr=1, cell_deg=cell_deg)
+
+    assert pars.shape == (2, 1, 3)
+    np.testing.assert_allclose(pars[0, 0], [8.0, 6.0, np.deg2rad(30.0)])
+    np.testing.assert_allclose(pars[1, 0], [16.0, 12.0, np.deg2rad(30.0)])
+
+
+def test_psfpars_from_header_falls_back_to_the_scalar_cards():
+    cell_deg = 1 / 3600
+    hdr = fits.Header()
+    hdr["BMAJ"] = 8.0 * cell_deg
+    hdr["BMIN"] = 6.0 * cell_deg
+    hdr["BPA"] = 0.0
+
+    pars = psfpars_from_header(hdr, nband=3, ncorr=2, cell_deg=cell_deg)
+
+    assert pars.shape == (3, 2, 3)
+    np.testing.assert_allclose(pars[:, :, 0], 8.0)
+
+
+def test_psfpars_from_header_raises_when_no_beam_is_present():
+    with pytest.raises(ValueError, match="BMAJ"):
+        psfpars_from_header(fits.Header(), nband=1, ncorr=1, cell_deg=1 / 3600)
+
+
+def test_product_vars_match_the_pfb_restore_contract():
+    assert PRODUCT_VARS == {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}

--- a/tests/test_datatree.py
+++ b/tests/test_datatree.py
@@ -145,3 +145,38 @@ def test_psfpars_from_header_raises_when_no_beam_is_present():
 
 def test_product_vars_match_the_pfb_restore_contract():
     assert PRODUCT_VARS == {"a": "BIMAGE", "i": "IMAGE", "k": "KIMAGE"}
+
+
+def test_pfb_tree_fixture_satisfies_the_contract(pfb_tree):
+    """The synthetic pfb tree is what every consumer is written against."""
+    dt = open_store(pfb_tree)
+    nodes = band_nodes(dt)
+
+    assert len(nodes) >= 2
+    assert dt.attrs["product"] == "I"
+
+    for node in nodes:
+        ds = dt[node].ds
+        require_vars(
+            ds,
+            ["IMAGE", "BIMAGE", "KIMAGE", "BEAM", "WSUM", "PSFPARSN", "PSFPARSF"],
+            node,
+            "the fixture is malformed",
+        )
+        assert ds.IMAGE.dims == ("corr", "y", "x")
+        assert ds.WSUM.dims == ("corr",)
+        assert ds.PSFPARSF.dims == ("corr", "bpar")
+        for key in ("bandid", "timeid", "freq_out", "ra", "dec", "cell_rad", "time_out"):
+            assert key in ds.attrs
+
+    check_homogeneous([dt[node].ds for node in nodes])
+
+
+def test_pfb_tree_partitions_declare_the_folded_n_term(pfb_tree):
+    """pfb stores BEAM as B/n; consumers must be able to detect that."""
+    dt = open_store(pfb_tree)
+    node = band_nodes(dt)[0]
+    parts = partition_nodes(dt, node)
+
+    assert parts == ["part0000"]
+    assert dt[f"{node}/{parts[0]}"].ds.attrs["beam_includes_n"] is True

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -6,8 +6,11 @@ from astropy.io import fits as afits
 
 from spimple.utils.fits import (
     add_beampars,
+    create_beams_table,
     data_from_header,
     expand_image_patterns,
+    freq_axis_of,
+    load_cube,
     load_fits,
     save_fits,
     set_wcs,
@@ -149,3 +152,107 @@ def test_add_beampars_writes_keywords(image_cube, beam_params):
 
     assert hdr["BMAJ"] == pytest.approx(beam_params[0])
     assert hdr["BMIN"] == pytest.approx(beam_params[1])
+
+
+def test_load_cube_is_identical_across_frequency_axis_conventions(image_cube, image_cube_ctype3):
+    """The two fixtures hold the same data under CTYPE4 and CTYPE3; load_cube must agree."""
+    cube4, freq4 = load_cube(image_cube)
+    cube3, freq3 = load_cube(image_cube_ctype3)
+
+    assert cube4.shape == cube3.shape
+    np.testing.assert_array_equal(cube4, cube3)
+    np.testing.assert_allclose(freq4, freq3)
+
+
+def test_load_cube_puts_band_first_and_keeps_the_raster(image_cube):
+    """Shape is (nband, ncorr, ny, nx) with the FITS rows and columns untouched."""
+    cube, freqs = load_cube(image_cube)
+    hdr = afits.getheader(image_cube)
+
+    assert cube.ndim == 4
+    assert cube.shape[0] == freqs.size
+    assert cube.shape[2] == hdr["NAXIS2"]
+    assert cube.shape[3] == hdr["NAXIS1"]
+
+    raw = afits.getdata(image_cube)
+    np.testing.assert_array_equal(cube[0, 0], raw[0, 0])
+
+
+def test_save_fits_yx_order_round_trips_through_load_cube(tmp_path):
+    """save_fits(yx_order=True) then load_cube is the identity on (nband, ncorr, ny, nx)."""
+    nband, ncorr, ny, nx = 3, 1, 5, 7
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=(nband, ncorr, ny, nx)).astype(np.float32)
+    freqs = np.array([1.0e9, 1.1e9, 1.2e9])
+
+    hdr = set_wcs(1 / 3600, 1 / 3600, nx, ny, (0.5, -0.5), freqs)
+    name = str(tmp_path / "cube.fits")
+    save_fits(name, data, hdr, yx_order=True)
+
+    out, out_freqs = load_cube(name)
+    np.testing.assert_allclose(out, data, rtol=1e-6)
+    np.testing.assert_allclose(out_freqs, freqs, rtol=1e-9)
+
+
+def test_freq_axis_of_detects_both_conventions(image_cube, image_cube_ctype3):
+    assert freq_axis_of(afits.getheader(image_cube)) == 4
+    assert freq_axis_of(afits.getheader(image_cube_ctype3)) == 3
+
+
+def test_set_wcs_reference_frequency_matches_crpix3():
+    """CRVAL3 must be the frequency of the channel CRPIX3 names, one-based."""
+    freqs = np.array([1.0e9, 1.1e9, 1.2e9, 1.3e9])
+    hdr = set_wcs(1 / 3600, 1 / 3600, 64, 64, (0.5, -0.5), freqs)
+
+    crpix3 = int(hdr["CRPIX3"])
+    assert hdr["CRVAL3"] == pytest.approx(freqs[crpix3 - 1])
+
+
+def test_set_wcs_handles_a_two_channel_cube():
+    """Two bands is spifit's minimum; it must not read out of bounds."""
+    freqs = np.array([1.0e9, 1.1e9])
+    hdr = set_wcs(1 / 3600, 1 / 3600, 64, 64, (0.5, -0.5), freqs)
+
+    assert hdr["CRVAL3"] == pytest.approx(freqs[int(hdr["CRPIX3"]) - 1])
+
+
+def test_set_wcs_unix_time_agrees_with_mjd_time():
+    """time_is_unix shifts the epoch; the same instant must render identically."""
+    mjd_seconds = 5.0e9
+    unix_seconds = mjd_seconds - 3506716800.0
+
+    from_mjd = set_wcs(1 / 3600, 1 / 3600, 8, 8, (0.5, -0.5), 1.0e9, ms_time=mjd_seconds)
+    from_unix = set_wcs(1 / 3600, 1 / 3600, 8, 8, (0.5, -0.5), 1.0e9, ms_time=unix_seconds, time_is_unix=True)
+
+    assert from_mjd["DATE-OBS"] == from_unix["DATE-OBS"]
+    assert from_mjd["UTC_TIME"] == from_unix["UTC_TIME"]
+
+
+def test_set_wcs_target_offset_shifts_crpix_not_crval():
+    """l0/m0 move the centre pixel; the tangent point stays put."""
+    cell = 1 / 3600
+    base = set_wcs(cell, cell, 64, 64, (0.5, -0.5), 1.0e9)
+    offset = set_wcs(cell, cell, 64, 64, (0.5, -0.5), 1.0e9, l0=np.deg2rad(cell), m0=0.0)
+
+    assert offset["CRVAL1"] == pytest.approx(base["CRVAL1"])
+    assert offset["CRPIX1"] == pytest.approx(base["CRPIX1"] + 1.0)
+    assert offset["CRPIX2"] == pytest.approx(base["CRPIX2"])
+
+
+def test_create_beams_table_converts_pixels_to_degrees():
+    import xarray as xr
+
+    cell_deg = 1 / 3600
+    pars = np.array([[[8.0, 6.0, 0.5]], [[4.0, 3.0, 0.5]]])  # (nband, ncorr, 3), pixels/radians
+    da = xr.DataArray(
+        pars,
+        dims=("band", "corr", "bpar"),
+        coords={"band": [0, 1], "corr": ["I"], "bpar": ["BMAJ", "BMIN", "BPA"]},
+    )
+
+    hdu = create_beams_table(da, cell2deg=cell_deg)
+
+    assert hdu.name == "BEAMS"
+    np.testing.assert_allclose(hdu.data["BMAJ"], [8.0 * cell_deg, 4.0 * cell_deg], rtol=1e-6)
+    np.testing.assert_allclose(hdu.data["BPA"], [np.rad2deg(0.5)] * 2, rtol=1e-6)
+    np.testing.assert_array_equal(hdu.data["CHAN"], [0, 1])

--- a/tests/test_imconv.py
+++ b/tests/test_imconv.py
@@ -112,3 +112,12 @@ def test_convolution_scales_flux_by_the_beam_area_ratio(image_cube, beam_params,
     expected_ratio = target_area / native_area
 
     assert convolved[-1].sum() / original[-1].sum() == pytest.approx(expected_ratio, rel=0.05)
+
+
+def test_imconv_warns_that_it_is_deprecated(image_cube, beam_params, tmp_path, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="spimple.IMCONV"):
+        imconv([image_cube], tmp_path / "conv", psf_pars=beam_params)
+
+    assert any("spimple init" in record.message for record in caplog.records)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,128 @@
+"""spimple init, the FITS-to-DataTree ingest."""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from spimple.core.init import init, resolve_target, store_name
+from spimple.utils.datatree import band_nodes, open_store
+
+CELL_DEG = 1.0 / 3600.0
+
+
+def test_store_name_appends_the_product():
+    assert store_name("/data/out", "I") == "/data/out_I.dt"
+
+
+def test_resolve_target_takes_the_largest_axes_times_dilate():
+    psfparsn = np.array([[[8.0, 6.0, 0.0]], [[4.0, 5.0, 0.0]]])  # (nband, ncorr, 3), pixels
+
+    target = resolve_target(psfparsn, None, False, 1.05, CELL_DEG)
+
+    np.testing.assert_allclose(target[0, 0], 8.0 * 1.05)
+    np.testing.assert_allclose(target[0, 1], 6.0 * 1.05)
+
+
+def test_resolve_target_converts_psf_pars_from_degrees_to_pixels():
+    psfparsn = np.array([[[8.0, 6.0, 0.0]]])
+
+    target = resolve_target(psfparsn, (10.0 * CELL_DEG, 9.0 * CELL_DEG, 30.0), False, 1.05, CELL_DEG)
+
+    np.testing.assert_allclose(target[0], [10.0, 9.0, np.deg2rad(30.0)])
+
+
+def test_resolve_target_rejects_a_target_finer_than_the_input():
+    psfparsn = np.array([[[8.0, 6.0, 0.0]]])
+
+    with pytest.raises(ValueError, match="finer"):
+        resolve_target(psfparsn, (4.0 * CELL_DEG, 3.0 * CELL_DEG, 0.0), False, 1.05, CELL_DEG)
+
+
+def test_resolve_target_circularises_when_asked():
+    psfparsn = np.array([[[8.0, 6.0, 0.3]]])
+
+    target = resolve_target(psfparsn, None, True, 1.0, CELL_DEG)
+
+    assert target[0, 0] == target[0, 1]
+    assert target[0, 2] == 0.0
+
+
+def test_init_writes_a_store_with_one_band_node_per_channel(image_cube, residual_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    nodes = band_nodes(dt)
+
+    assert len(nodes) == 4
+    assert [int(dt[n].ds.attrs["bandid"]) for n in nodes] == [0, 1, 2, 3]
+    assert dt.attrs["product"] == "I"
+
+
+def test_init_populates_the_band_node_for_a_single_partition(image_cube, residual_cube, tmp_path):
+    """One pointing needs no mosaic step, so init writes the band products itself."""
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    ds = dt[band_nodes(dt)[0]].ds
+
+    for name in ("IMAGE", "BIMAGE", "KIMAGE", "BEAM", "WSUM", "RMS", "PSFPARSF"):
+        assert name in ds, f"{name} missing from the band node"
+    assert ds.IMAGE.dims == ("corr", "y", "x")
+
+
+def test_init_homogenises_every_band_to_one_resolution(image_cube, residual_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    pars = np.stack([dt[n].ds.PSFPARSF.values for n in band_nodes(dt)])
+
+    assert pars.shape[0] == 4
+    for band in pars:
+        np.testing.assert_allclose(band, pars[0], rtol=1e-9)
+
+
+def test_init_takes_wsum_from_the_channel_weights_keyword(image_cube, residual_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    wsum = dt[band_nodes(dt)[0]].ds.WSUM.values
+
+    # the residual_cube fixture carries WSCVWSUM = 1.0
+    np.testing.assert_allclose(wsum, 1.0)
+
+
+def test_init_without_a_beam_leaves_the_flux_scales_equal(image_cube, residual_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    ds = dt[band_nodes(dt)[0]].ds
+
+    np.testing.assert_allclose(ds.BEAM.values, 1.0)
+    np.testing.assert_allclose(ds.IMAGE.values, ds.BIMAGE.values, atol=1e-6)
+
+
+def test_init_refuses_to_clobber_without_overwrite(image_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, overwrite=True)
+
+    with pytest.raises(FileExistsError):
+        init([image_cube], out, overwrite=False)
+
+
+def test_init_renders_requested_fits(image_cube, residual_cube, tmp_path):
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], fits_outputs="I", overwrite=True)
+
+    written = sorted((tmp_path / "fits").glob("*.fits"))
+    assert written, "no FITS rendered"
+    assert fits.getdata(str(written[0])).ndim == 4
+
+
+def test_init_rejects_a_beam_model_until_task_12(image_cube, tmp_path):
+    with pytest.raises(NotImplementedError, match="beam"):
+        init([image_cube], str(tmp_path / "out"), beam_model="JimBeam", overwrite=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -210,3 +210,97 @@ def test_init_uses_each_partition_s_own_pointing_for_the_beam(two_pointing_fits,
         peaks.append(np.unravel_index(np.argmax(beam), beam.shape))
 
     assert peaks[0] != peaks[1], "both beams peak at the same pixel; the pointing was ignored"
+
+
+def _single_band_fits(path, freq, bmaj_deg, npix=32, ra=30.0):
+    """One channel, one file, with its own scalar beam cards."""
+    hdr = fits.Header()
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CRVAL1"] = ra
+    hdr["CRPIX1"] = npix // 2 + 1
+    hdr["CDELT1"] = -CELL_DEG
+    hdr["CUNIT1"] = "deg"
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CRVAL2"] = -30.0
+    hdr["CRPIX2"] = npix // 2 + 1
+    hdr["CDELT2"] = CELL_DEG
+    hdr["CUNIT2"] = "deg"
+    hdr["CTYPE4"] = "FREQ"
+    hdr["CRVAL4"] = float(freq)
+    hdr["CRPIX4"] = 1
+    hdr["CDELT4"] = 1.0e8
+    hdr["CTYPE3"] = "STOKES"
+    hdr["CRVAL3"] = 1.0
+    hdr["CRPIX3"] = 1
+    hdr["CDELT3"] = 1.0
+    hdr["BMAJ"] = float(bmaj_deg)
+    hdr["BMIN"] = float(bmaj_deg)
+    hdr["BPA"] = 0.0
+    data = np.zeros((1, 1, npix, npix), dtype=np.float32)
+    data[0, 0, 5, 7] = 1.0
+    fits.writeto(path, data, hdr, overwrite=True)
+    return str(path)
+
+
+def test_init_labels_planes_correctly_on_a_descending_frequency_axis(tmp_path):
+    """A cube whose CDELT4 is negative must not have its spectrum reversed."""
+    npix = 32
+    freqs = [1.3e9, 1.2e9, 1.1e9, 1.0e9]
+    hdr = fits.Header()
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CRVAL1"] = 30.0
+    hdr["CRPIX1"] = npix // 2 + 1
+    hdr["CDELT1"] = -CELL_DEG
+    hdr["CUNIT1"] = "deg"
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CRVAL2"] = -30.0
+    hdr["CRPIX2"] = npix // 2 + 1
+    hdr["CDELT2"] = CELL_DEG
+    hdr["CUNIT2"] = "deg"
+    hdr["CTYPE4"] = "FREQ"
+    hdr["CRVAL4"] = freqs[0]
+    hdr["CRPIX4"] = 1
+    hdr["CDELT4"] = freqs[1] - freqs[0]  # negative
+    hdr["CTYPE3"] = "STOKES"
+    hdr["CRVAL3"] = 1.0
+    hdr["CRPIX3"] = 1
+    hdr["CDELT3"] = 1.0
+    hdr["BMAJ"] = 6.0 * CELL_DEG
+    hdr["BMIN"] = 6.0 * CELL_DEG
+    hdr["BPA"] = 0.0
+    data = np.zeros((4, 1, npix, npix), dtype=np.float32)
+    for i in range(4):
+        data[i, 0, 5, 7] = float(i + 1)  # plane i, at freqs[i], carries value i+1
+    path = str(tmp_path / "desc.fits")
+    fits.writeto(path, data, hdr, overwrite=True)
+
+    out = str(tmp_path / "out")
+    init([path], out, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    for node in band_nodes(dt):
+        ds = dt[node].ds
+        freq = float(ds.attrs["freq_out"])
+        expected = freqs.index(pytest.approx(freq)) + 1 if False else None
+        # the plane written at this frequency carried value (index in freqs) + 1
+        idx = min(range(4), key=lambda i: abs(freqs[i] - freq))
+        expected = idx + 1
+        assert ds.IMAGE.values[0, 5, 7] == pytest.approx(expected, rel=0.1), (
+            f"{node} at {freq:.3e} Hz carries the wrong plane"
+        )
+
+
+def test_init_reads_the_beam_from_each_source_file(tmp_path):
+    """Split single-channel files each carry their own scalar BMAJ."""
+    beams = [6.0, 5.0, 4.0]
+    files = [
+        _single_band_fits(tmp_path / f"s-{i:04d}.fits", 1.0e9 + i * 1.0e8, b * CELL_DEG) for i, b in enumerate(beams)
+    ]
+
+    out = str(tmp_path / "out")
+    init(files, out, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    recorded = [np.asarray(dt[f"{n}/part0000"].ds.attrs["psfparsn"])[0][0] for n in band_nodes(dt)]
+
+    np.testing.assert_allclose(recorded, beams, rtol=1e-6)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -123,6 +123,90 @@ def test_init_renders_requested_fits(image_cube, residual_cube, tmp_path):
     assert fits.getdata(str(written[0])).ndim == 4
 
 
-def test_init_rejects_a_beam_model_until_task_12(image_cube, tmp_path):
-    with pytest.raises(NotImplementedError, match="beam"):
-        init([image_cube], str(tmp_path / "out"), beam_model="JimBeam", overwrite=True)
+def test_init_writes_one_partition_per_pointing(two_pointing_fits, tmp_path):
+    from spimple.utils.datatree import partition_nodes
+
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "out")
+    init(models, out, residual=residuals, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    node = band_nodes(dt)[0]
+
+    assert partition_nodes(dt, node) == ["part0000", "part0001"]
+
+
+def test_init_leaves_the_band_node_bare_for_multiple_partitions(two_pointing_fits, tmp_path):
+    """Combining is mosaic's job; init must not guess a band-level image."""
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "out")
+    init(models, out, residual=residuals, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    ds = dt[band_nodes(dt)[0]].ds
+
+    assert "IMAGE" not in ds
+    assert "PSFPARSF" in ds
+    assert "cell_rad" in ds.attrs
+
+
+def test_init_puts_every_partition_on_the_union_grid(two_pointing_fits, tmp_path):
+    from spimple.utils.datatree import partition_nodes
+
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "out")
+    init(models, out, residual=residuals, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    node = band_nodes(dt)[0]
+    shapes = {dt[f"{node}/{p}"].ds.IMAGE.shape for p in partition_nodes(dt, node)}
+
+    assert len(shapes) == 1
+    assert dt.attrs["nx"] > 64  # wider than one pointing
+
+
+def test_init_masks_each_partition_to_its_own_footprint(two_pointing_fits, tmp_path):
+    from spimple.utils.datatree import partition_nodes
+
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "out")
+    init(models, out, residual=residuals, overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    node = band_nodes(dt)[0]
+    masks = [dt[f"{node}/{p}"].ds.MASK.values[0] for p in partition_nodes(dt, node)]
+
+    assert not masks[0].all()
+    assert (masks[0] & masks[1]).any(), "the pointings should overlap"
+    assert not (masks[0] & masks[1]).all(), "the pointings should not coincide"
+
+
+def test_init_applies_a_jimbeam_to_each_partition(image_cube, residual_cube, tmp_path):
+    pytest.importorskip("katbeam")
+    out = str(tmp_path / "out")
+    init([image_cube], out, residual=[residual_cube], beam_model="JimBeam", overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    ds = dt[band_nodes(dt)[0]].ds
+
+    assert ds.BEAM.values.max() <= 1.0 + 1e-6
+    assert ds.BEAM.values.min() < 1.0
+
+
+def test_init_uses_each_partition_s_own_pointing_for_the_beam(two_pointing_fits, tmp_path):
+    """Beams are evaluated around each partition's phase centre, not a shared one."""
+    pytest.importorskip("katbeam")
+    from spimple.utils.datatree import partition_nodes
+
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "out")
+    init(models, out, residual=residuals, beam_model="JimBeam", overwrite=True)
+
+    dt = open_store(store_name(out, "I"))
+    node = band_nodes(dt)[0]
+    peaks = []
+    for part in partition_nodes(dt, node):
+        beam = dt[f"{node}/{part}"].ds.BEAM.values[0]
+        peaks.append(np.unravel_index(np.argmax(beam), beam.shape))
+
+    assert peaks[0] != peaks[1], "both beams peak at the same pixel; the pointing was ignored"

--- a/tests/test_init_grouping.py
+++ b/tests/test_init_grouping.py
@@ -1,0 +1,127 @@
+"""How init maps a pile of FITS files onto the tree's band and partition axes."""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from spimple.core.init import assign_bands, field_name_for, group_partitions, partition_key
+
+CELL_DEG = 1.0 / 3600.0
+
+
+def _write(path, ra, dec, freqs, npix=8):
+    hdr = fits.Header()
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CRVAL1"] = ra
+    hdr["CRPIX1"] = npix // 2 + 1
+    hdr["CDELT1"] = -CELL_DEG
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CRVAL2"] = dec
+    hdr["CRPIX2"] = npix // 2 + 1
+    hdr["CDELT2"] = CELL_DEG
+    hdr["CTYPE4"] = "FREQ"
+    hdr["CRVAL4"] = float(freqs[0])
+    hdr["CRPIX4"] = 1
+    hdr["CDELT4"] = float(freqs[1] - freqs[0]) if len(freqs) > 1 else 1.0e8
+    hdr["CTYPE3"] = "STOKES"
+    hdr["CRVAL3"] = 1.0
+    hdr["CRPIX3"] = 1
+    hdr["CDELT3"] = 1.0
+    data = np.zeros((len(freqs), 1, npix, npix), dtype=np.float32)
+    fits.writeto(path, data, hdr, overwrite=True)
+    return str(path)
+
+
+def test_files_sharing_a_phase_centre_and_grid_form_one_partition(tmp_path):
+    a0 = _write(tmp_path / "fieldA-0000.fits", 30.0, -30.0, [1.0e9])
+    a1 = _write(tmp_path / "fieldA-0001.fits", 30.0, -30.0, [1.1e9])
+    b0 = _write(tmp_path / "fieldB-0000.fits", 31.0, -30.0, [1.0e9])
+
+    groups = group_partitions([a0, a1, b0])
+
+    assert len(groups) == 2
+    assert sorted(groups[0][1]) == sorted([a0, a1])
+    assert groups[1][1] == [b0]
+
+
+def test_partitions_are_ordered_by_phase_centre(tmp_path):
+    east = _write(tmp_path / "e.fits", 31.0, -30.0, [1.0e9])
+    west = _write(tmp_path / "w.fits", 30.0, -30.0, [1.0e9])
+
+    groups = group_partitions([east, west])
+
+    assert groups[0][1] == [west]
+    assert groups[1][1] == [east]
+
+
+def test_a_different_grid_size_splits_the_partition(tmp_path):
+    small = _write(tmp_path / "small.fits", 30.0, -30.0, [1.0e9], npix=8)
+    large = _write(tmp_path / "large.fits", 30.0, -30.0, [1.0e9], npix=16)
+
+    assert len(group_partitions([small, large])) == 2
+
+
+def test_partition_key_is_insensitive_to_floating_point_noise(tmp_path):
+    a = _write(tmp_path / "a.fits", 30.0, -30.0, [1.0e9])
+    b = _write(tmp_path / "b.fits", 30.0 + 1e-12, -30.0, [1.0e9])
+
+    assert partition_key(fits.getheader(a)) == partition_key(fits.getheader(b))
+
+
+def test_matching_frequencies_across_partitions_share_a_band():
+    freqs = [np.array([1.0e9, 1.1e9]), np.array([1.0e9, 1.1e9])]
+
+    nominal, mapping = assign_bands(freqs, freq_tol=None)
+
+    np.testing.assert_allclose(nominal, [1.0e9, 1.1e9])
+    assert mapping == [{0: 0, 1: 1}, {0: 0, 1: 1}]
+
+
+def test_a_partition_missing_a_band_simply_omits_it():
+    freqs = [np.array([1.0e9, 1.1e9]), np.array([1.1e9])]
+
+    nominal, mapping = assign_bands(freqs, freq_tol=None)
+
+    np.testing.assert_allclose(nominal, [1.0e9, 1.1e9])
+    assert mapping == [{0: 0, 1: 1}, {1: 0}]
+
+
+def test_frequencies_within_the_tolerance_are_one_band():
+    freqs = [np.array([1.0e9]), np.array([1.0e9 + 1.0e6])]
+
+    nominal, mapping = assign_bands(freqs, freq_tol=1.0e7)
+
+    assert nominal.size == 1
+    assert mapping == [{0: 0}, {0: 0}]
+
+
+def test_two_channels_of_one_partition_in_one_band_is_an_error():
+    freqs = [np.array([1.0e9, 1.0e9 + 1.0e6])]
+
+    with pytest.raises(ValueError, match="two channels"):
+        assign_bands(freqs, freq_tol=1.0e7)
+
+
+def test_field_name_is_the_common_prefix_of_the_group(tmp_path):
+    paths = [str(tmp_path / "deep2-0000-image.fits"), str(tmp_path / "deep2-0001-image.fits")]
+
+    assert field_name_for(paths, 0) == "deep2"
+
+
+def test_field_name_falls_back_to_the_partition_id(tmp_path):
+    paths = [str(tmp_path / "alpha.fits"), str(tmp_path / "beta.fits")]
+
+    assert field_name_for(paths, 3) == "part0003"
+
+
+def test_field_name_keeps_a_digit_that_is_part_of_the_name(tmp_path):
+    """deep2 must not become deep just because the name ends in a digit."""
+    paths = [str(tmp_path / "deep2.fits"), str(tmp_path / "deep2.fits")]
+
+    assert field_name_for(paths, 0) == "deep2"
+
+
+def test_field_name_strips_a_wsclean_channel_counter(tmp_path):
+    paths = [str(tmp_path / "img_01-image.fits"), str(tmp_path / "img_02-image.fits")]
+
+    assert field_name_for(paths, 0) == "img"

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,62 +1,131 @@
-"""Coverage for `spimple mosaic`.
-
-The end-to-end path is not exercised here: `mosaic` requires a primary beam in
-the meerkat-beams `.bds.zarr` format and has no code path for running without
-one, so a hermetic end-to-end test would have to synthesise that dataset. See
-test_end_to_end_needs_a_bds_beam below.
-
-What is covered is `mosaic_info`, which does the coordinate-frame and output-naming
-work and runs on plain FITS.
-"""
+"""Combining image-space partitions into a band image."""
 
 import numpy as np
-import pytest
-from astropy.wcs import WCS
 
-from spimple.utils.mosaic import mosaic_info
+from spimple.utils.mosaic import conjugate_gradient, stitch_band
 
-
-def test_mosaic_info_derives_a_common_frame(image_cube_ctype3, tmp_path):
-    """A single input's optimal frame must cover it and carry its frequencies."""
-    ref_wcs, ufreqs, out_names = mosaic_info([image_cube_ctype3], str(tmp_path / "mos.fits"))
-
-    assert isinstance(ref_wcs, WCS)
-    assert ref_wcs.array_shape is not None
-    assert ufreqs.size == 4
-    assert np.all(np.diff(ufreqs) > 0), "frequencies must come back sorted and unique"
+NY, NX = 16, 24
 
 
-def test_mosaic_info_names_one_output_per_corr_and_channel(image_cube_ctype3, tmp_path):
-    """out_names drives the per-slice zarr scratch products."""
-    _, _, out_names = mosaic_info([image_cube_ctype3], str(tmp_path / "mos.fits"))
-
-    # fixture is 1 correlation x 4 channels
-    assert len(out_names) == 4
-    assert all(name.endswith(".zarr") for name in out_names)
-    assert all("_im0_" in name for name in out_names)
+def _beam(shift, sigma=8.0):
+    v_y = np.arange(NY) - NY // 2
+    v_x = np.arange(NX) - NX // 2 - shift
+    yy, xx = np.meshgrid(v_y, v_x, indexing="ij")
+    return np.exp(-(xx**2 + yy**2) / (2 * sigma**2))
 
 
-def test_mosaic_info_deduplicates_shared_frequencies(image_cube_ctype3, tmp_path):
-    """The same cube twice spans the same band, so ufreqs must not double up."""
-    _, ufreqs, out_names = mosaic_info([image_cube_ctype3, image_cube_ctype3], str(tmp_path / "mos.fits"))
-
-    assert ufreqs.size == 4, "identical inputs must not multiply the frequency axis"
-    assert len(out_names) == 8, "but each input still gets its own scratch products"
-
-
-def test_mosaic_info_rejects_a_reference_image(image_cube_ctype3, tmp_path):
-    """ref_image is declared but not implemented; it must say so rather than ignore it."""
-    with pytest.raises(NotImplementedError, match="Reference image"):
-        mosaic_info([image_cube_ctype3], str(tmp_path / "mos.fits"), ref_image=image_cube_ctype3)
+def _scene(shifts, sky=None):
+    sky = np.ones((NY, NX)) if sky is None else sky
+    beams = np.stack([_beam(s)[None] for s in shifts])
+    apparent = beams * sky[None, None]
+    masks = np.ones((len(shifts), NY, NX), dtype=bool)
+    return sky, apparent, beams, masks
 
 
-@pytest.mark.skip(
-    reason=(
-        "`mosaic` cannot run without a primary beam: utils/mosaic.project calls "
-        "xr.open_zarr(beam) unconditionally, so beam=None dies with an opaque "
-        "zarr GroupNotFoundError. Covering this end to end needs a synthetic "
-        "meerkat-beams .bds.zarr fixture."
-    )
-)
-def test_end_to_end_needs_a_bds_beam(image_cube_ctype3, tmp_path):
-    """Placeholder for the real end-to-end mosaic test."""
+def test_stitch_recovers_the_intrinsic_sky():
+    rng = np.random.default_rng(4)
+    sky = 1.0 + rng.uniform(size=(NY, NX))
+    _, apparent, beams, masks = _scene([-4, 4], sky=sky)
+
+    out = stitch_band(apparent, beams, masks, eta=1e-8)
+
+    np.testing.assert_allclose(out["IMAGE"][0], sky, rtol=1e-5)
+
+
+def test_stitch_beam_reduces_to_the_common_beam():
+    """Identical partition beams must give BEAM == B."""
+    _, apparent, beams, masks = _scene([0, 0])
+
+    out = stitch_band(apparent, beams, masks, eta=0.0)
+
+    np.testing.assert_allclose(out["BEAM"][0], beams[0, 0], rtol=1e-9)
+
+
+def test_stitch_beam_reduces_to_the_only_covering_partition():
+    """Where one partition alone covers a pixel, BEAM is that partition's beam."""
+    _, apparent, beams, masks = _scene([-6, 6])
+    masks[1, :, : NX // 2] = False
+
+    out = stitch_band(apparent, beams, masks, eta=0.0)
+
+    np.testing.assert_allclose(out["BEAM"][0, :, 0], beams[0, 0, :, 0], rtol=1e-9)
+
+
+def test_bimage_is_the_beam_weighted_mean_apparent_image():
+    _, apparent, beams, masks = _scene([-4, 4])
+
+    out = stitch_band(apparent, beams, masks, eta=0.0)
+
+    expected = (beams * apparent).sum(axis=0) / beams.sum(axis=0)
+    np.testing.assert_allclose(out["BIMAGE"], expected, rtol=1e-9)
+    np.testing.assert_allclose(out["BIMAGE"], out["BEAM"] * out["IMAGE"], rtol=1e-6)
+
+
+def test_spatial_weight_is_the_sum_of_squared_beams():
+    _, apparent, beams, masks = _scene([-4, 4])
+    eta = 1e-3
+
+    out = stitch_band(apparent, beams, masks, eta=eta)
+
+    np.testing.assert_allclose(out["SPATIALWGT"], (beams**2).sum(axis=0) + eta, rtol=1e-9)
+
+
+def test_masked_partitions_do_not_contribute():
+    _, apparent, beams, masks = _scene([-4, 4])
+    masks[1] = False
+    apparent[1] = 1e6  # would dominate if it leaked in
+
+    out = stitch_band(apparent, beams, masks, eta=1e-8)
+
+    np.testing.assert_allclose(out["IMAGE"][0], 1.0, rtol=1e-5)
+
+
+def test_uncovered_pixels_are_zero_not_nan():
+    _, apparent, beams, masks = _scene([-4, 4])
+    masks[:, :, 0] = False
+
+    out = stitch_band(apparent, beams, masks, eta=0.0)
+
+    assert np.isfinite(out["IMAGE"]).all()
+    np.testing.assert_allclose(out["IMAGE"][:, :, 0], 0.0)
+
+
+def test_mixed_scale_is_averaged_not_resolved():
+    _, apparent, beams, masks = _scene([-4, 4])
+    mixed = apparent + 0.5
+
+    out = stitch_band(apparent, beams, masks, mixed=mixed, eta=0.0)
+
+    expected = (beams * mixed).sum(axis=0) / beams.sum(axis=0)
+    np.testing.assert_allclose(out["KIMAGE"], expected, rtol=1e-9)
+
+
+def test_wsum_and_rms_are_propagated():
+    _, apparent, beams, masks = _scene([-4, 4])
+    wsums = np.array([[1.0], [3.0]])
+    rms = np.array([[0.1], [0.2]])
+
+    out = stitch_band(apparent, beams, masks, wsums=wsums, rms=rms, eta=0.0)
+
+    np.testing.assert_allclose(out["WSUM"], [4.0])
+    assert out["RMS"][0] > 0.0
+
+
+def test_the_direct_solve_agrees_with_conjugate_gradient():
+    """The normal equations are diagonal, so CG must reach the same fixed point."""
+    rng = np.random.default_rng(9)
+    sky = 1.0 + rng.uniform(size=(NY, NX))
+    _, apparent, beams, masks = _scene([-4, 4], sky=sky)
+    eta = 1e-4
+
+    direct = stitch_band(apparent, beams, masks, eta=eta)["IMAGE"][0]
+
+    rhs = (beams[:, 0] * apparent[:, 0] * masks).sum(axis=0)
+    diag = (beams[:, 0] ** 2 * masks).sum(axis=0) + eta
+
+    def hess(x):
+        return diag * x
+
+    cg, _ = conjugate_gradient(hess, rhs, max_iter=50, tol=1e-14)
+
+    np.testing.assert_allclose(direct, cg, rtol=1e-8)

--- a/tests/test_mosaic_command.py
+++ b/tests/test_mosaic_command.py
@@ -1,0 +1,72 @@
+"""spimple mosaic, the partition combiner."""
+
+import numpy as np
+import pytest
+
+from spimple.core.init import init, store_name
+from spimple.core.mosaic import mosaic
+from spimple.utils.datatree import band_nodes, open_store
+
+
+@pytest.fixture
+def two_pointing_store(two_pointing_fits, tmp_path):
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "mos")
+    init(models, out, residual=residuals, overwrite=True)
+    return store_name(out, "I")
+
+
+def test_mosaic_populates_every_band_node(two_pointing_store):
+    mosaic(two_pointing_store, fits_outputs="")
+
+    dt = open_store(two_pointing_store)
+    for node in band_nodes(dt):
+        ds = dt[node].ds
+        for name in ("IMAGE", "BIMAGE", "KIMAGE", "BEAM", "WSUM", "SPATIALWGT"):
+            assert name in ds, f"{name} missing from {node}"
+        assert ds.IMAGE.dims == ("corr", "y", "x")
+
+
+def test_mosaic_preserves_the_band_attributes(two_pointing_store):
+    dt = open_store(two_pointing_store)
+    before = {n: dict(dt[n].ds.attrs) for n in band_nodes(dt)}
+
+    mosaic(two_pointing_store, fits_outputs="")
+
+    dt = open_store(two_pointing_store)
+    for node, attrs in before.items():
+        for key in ("bandid", "timeid", "freq_out", "cell_rad", "ra", "dec"):
+            assert dt[node].ds.attrs[key] == attrs[key]
+
+
+def test_mosaic_output_is_finite_everywhere(two_pointing_store):
+    mosaic(two_pointing_store, fits_outputs="")
+
+    dt = open_store(two_pointing_store)
+    for node in band_nodes(dt):
+        assert np.isfinite(dt[node].ds.IMAGE.values).all()
+
+
+def test_mosaic_is_idempotent(two_pointing_store):
+    mosaic(two_pointing_store, fits_outputs="")
+    dt = open_store(two_pointing_store)
+    first = dt[band_nodes(dt)[0]].ds.IMAGE.values.copy()
+
+    mosaic(two_pointing_store, fits_outputs="")
+    dt = open_store(two_pointing_store)
+    second = dt[band_nodes(dt)[0]].ds.IMAGE.values
+
+    np.testing.assert_allclose(first, second, rtol=1e-9)
+
+
+def test_mosaic_renders_the_requested_fits(two_pointing_store, tmp_path):
+    folder = tmp_path / "rendered"
+    mosaic(two_pointing_store, fits_outputs="I", fits_output_folder=str(folder))
+
+    assert sorted(folder.glob("*.fits")), "no FITS rendered"
+
+
+def test_mosaic_refuses_a_store_with_no_image_partitions(pfb_tree):
+    """A pfb tree mosaics in visibility space; there is nothing here to combine."""
+    with pytest.raises(ValueError, match="already populated"):
+        mosaic(pfb_tree, fits_outputs="")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,106 @@
+"""The union grid and the reprojection onto it."""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from spimple.utils.project import reproject_cube, same_frame, union_wcs
+
+CELL_DEG = 10.0 / 3600.0
+NPIX = 32
+
+
+def _hdr(ra, dec, npix=NPIX):
+    hdr = fits.Header()
+    hdr["NAXIS"] = 2
+    hdr["NAXIS1"] = npix
+    hdr["NAXIS2"] = npix
+    hdr["CTYPE1"] = "RA---SIN"
+    hdr["CRVAL1"] = ra
+    hdr["CRPIX1"] = npix // 2 + 1
+    hdr["CDELT1"] = -CELL_DEG
+    hdr["CUNIT1"] = "deg"
+    hdr["CTYPE2"] = "DEC--SIN"
+    hdr["CRVAL2"] = dec
+    hdr["CRPIX2"] = npix // 2 + 1
+    hdr["CDELT2"] = CELL_DEG
+    hdr["CUNIT2"] = "deg"
+    return hdr
+
+
+def test_union_of_one_header_is_that_header_s_frame():
+    hdr = _hdr(30.0, -30.0)
+
+    wcs, shape = union_wcs([hdr])
+
+    assert shape == (NPIX, NPIX)
+    assert same_frame(wcs, shape, WCS(hdr).celestial, (NPIX, NPIX))
+
+
+def test_union_of_two_offset_pointings_covers_both():
+    a = _hdr(30.0, -30.0)
+    b = _hdr(30.0 + 20 * CELL_DEG, -30.0)
+
+    wcs, shape = union_wcs([a, b])
+
+    assert shape[1] > NPIX  # wider in x to hold both pointings
+    for hdr in (a, b):
+        centre = WCS(hdr).celestial.pixel_to_world(NPIX // 2, NPIX // 2)
+        x, y = wcs.world_to_pixel(centre)
+        assert 0 <= x < shape[1]
+        assert 0 <= y < shape[0]
+
+
+def test_same_frame_rejects_a_shifted_reference():
+    a = _hdr(30.0, -30.0)
+    b = _hdr(30.1, -30.0)
+
+    assert not same_frame(WCS(a).celestial, (NPIX, NPIX), WCS(b).celestial, (NPIX, NPIX))
+
+
+def test_same_frame_rejects_a_different_shape():
+    hdr = _hdr(30.0, -30.0)
+
+    assert not same_frame(WCS(hdr).celestial, (NPIX, NPIX), WCS(hdr).celestial, (NPIX, NPIX + 2))
+
+
+def test_reproject_onto_the_same_frame_is_a_near_identity():
+    hdr = _hdr(30.0, -30.0)
+    wcs = WCS(hdr).celestial
+    rng = np.random.default_rng(1)
+    cube = rng.normal(size=(1, NPIX, NPIX))
+
+    out, mask = reproject_cube(cube, wcs, wcs, (NPIX, NPIX))
+
+    assert mask.all()
+    np.testing.assert_allclose(out, cube, atol=1e-9)
+
+
+def test_reproject_moves_a_source_to_the_predicted_pixel():
+    """A source at a known sky position must land where the target WCS says."""
+    src_hdr = _hdr(30.0, -30.0)
+    src_wcs = WCS(src_hdr).celestial
+    cube = np.zeros((1, NPIX, NPIX))
+    y0, x0 = 8, 21
+    cube[0, y0, x0] = 1.0
+
+    tgt_wcs, shape = union_wcs([src_hdr, _hdr(30.0 + 20 * CELL_DEG, -30.0)])
+    out, mask = reproject_cube(cube, src_wcs, tgt_wcs, shape)
+
+    sky = src_wcs.pixel_to_world(x0, y0)
+    xt, yt = tgt_wcs.world_to_pixel(sky)
+    peak = np.unravel_index(np.argmax(out[0]), out[0].shape)
+    assert peak[0] == pytest.approx(yt, abs=1.0)
+    assert peak[1] == pytest.approx(xt, abs=1.0)
+
+
+def test_reproject_masks_the_region_outside_the_footprint():
+    src_hdr = _hdr(30.0, -30.0)
+    tgt_wcs, shape = union_wcs([src_hdr, _hdr(30.0 + 40 * CELL_DEG, -30.0)])
+    cube = np.ones((1, NPIX, NPIX))
+
+    out, mask = reproject_cube(cube, WCS(src_hdr).celestial, tgt_wcs, shape)
+
+    assert not mask.all()
+    np.testing.assert_allclose(out[0][~mask], 0.0)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,114 @@
+"""Rendering band-node variables back to FITS.
+
+The orientation test here is the one that catches a (Y, X) mistake; every other
+test in the suite passes while the image is transposed.
+"""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+
+from spimple.utils.datatree import band_node_name, create_store, write_node
+from spimple.utils.render import dt2fits
+
+CELL_DEG = 1.0 / 3600.0
+BPAR = ["BMAJ", "BMIN", "BPA"]
+NY, NX = 24, 32
+Y0, X0 = 5, 27  # deliberately asymmetric, and inside a non-square raster
+
+
+@pytest.fixture
+def spike_tree(tmp_path):
+    """Two bands, each a single bright pixel at (Y0, X0) on a non-square grid."""
+    url = str(tmp_path / "spike_I.dt")
+    create_store(
+        url,
+        {"product": "I", "nband": 2, "ntime": 1, "nx": NX, "ny": NY, "cell_rad": np.deg2rad(CELL_DEG)},
+        overwrite=True,
+    )
+    for band in range(2):
+        data = np.zeros((1, NY, NX), dtype=np.float32)
+        data[0, Y0, X0] = 1.0 + band
+        write_node(
+            url,
+            band_node_name(band, 0),
+            {
+                "IMAGE": (("corr", "y", "x"), data),
+                "WSUM": (("corr",), np.array([1.0 + band], dtype=np.float32)),
+                "PSFPARSF": (("corr", "bpar"), np.array([[8.0, 6.0, 0.0]], dtype=np.float32)),
+            },
+            {
+                "bandid": band,
+                "timeid": 0,
+                "freq_out": 1.0e9 + band * 1.0e8,
+                "time_out": 1.0e9,
+                "ra": np.deg2rad(30.0),
+                "dec": np.deg2rad(-30.0),
+                "cell_rad": np.deg2rad(CELL_DEG),
+                "l0": 0.0,
+                "m0": 0.0,
+            },
+            {"corr": ["I"], "bpar": BPAR},
+        )
+    return url
+
+
+def test_render_preserves_the_raster(spike_tree, tmp_path):
+    """The bright pixel must land at [.., Y0, X0] in the FITS array, not transposed."""
+    written = dt2fits(spike_tree, "IMAGE", str(tmp_path / "out"), do_mfs=False)
+    assert len(written) == 1
+
+    data = fits.getdata(written[0])
+    assert data.shape[-2:] == (NY, NX)
+    for band in range(2):
+        peak = np.unravel_index(np.argmax(data[0, band]), data[0, band].shape)
+        assert peak == (Y0, X0)
+
+
+def test_render_wcs_agrees_with_the_raster(spike_tree, tmp_path):
+    """The header must describe the pixel the data actually occupies."""
+    written = dt2fits(spike_tree, "IMAGE", str(tmp_path / "out"), do_mfs=False)
+    hdr = fits.getheader(written[0])
+    wcs = WCS(hdr).celestial
+
+    sky = wcs.pixel_to_world(X0, Y0)
+    ref = wcs.pixel_to_world(hdr["CRPIX1"] - 1, hdr["CRPIX2"] - 1)
+
+    # CDELT1 is negative, so RA decreases with increasing x
+    d_ra = (sky.ra.deg - ref.ra.deg) * np.cos(np.deg2rad(ref.dec.deg))
+    d_dec = sky.dec.deg - ref.dec.deg
+    assert d_ra == pytest.approx(-(X0 - (hdr["CRPIX1"] - 1)) * CELL_DEG, rel=1e-3)
+    assert d_dec == pytest.approx((Y0 - (hdr["CRPIX2"] - 1)) * CELL_DEG, rel=1e-3)
+
+
+def test_render_mfs_is_the_wsum_weighted_mean(spike_tree, tmp_path):
+    written = dt2fits(spike_tree, "IMAGE", str(tmp_path / "out"), do_cube=False)
+    assert len(written) == 1
+
+    data = fits.getdata(written[0])
+    # band values 1 and 2 with wsums 1 and 2 -> (1*1 + 2*2)/3
+    assert data[0, 0, Y0, X0] == pytest.approx((1.0 * 1.0 + 2.0 * 2.0) / 3.0, rel=1e-5)
+
+
+def test_render_writes_a_beams_table_from_psfparsf(spike_tree, tmp_path):
+    written = dt2fits(spike_tree, "IMAGE", str(tmp_path / "out"), do_mfs=False)
+
+    with fits.open(written[0]) as hdul:
+        assert "BEAMS" in hdul
+        beams = hdul["BEAMS"].data
+        np.testing.assert_allclose(beams["BMAJ"], [8.0 * CELL_DEG] * 2, rtol=1e-5)
+        assert hdul[0].header["BMAJ"] == pytest.approx(8.0 * CELL_DEG, rel=1e-5)
+
+
+def test_render_skips_a_column_no_band_carries(spike_tree, tmp_path):
+    assert dt2fits(spike_tree, "BIMAGE", str(tmp_path / "out")) == []
+
+
+def test_render_handles_the_two_band_minimum(pfb_tree, tmp_path):
+    """A cube of any size must render; set_wcs used to read out of bounds at nband 2."""
+    written = dt2fits(pfb_tree, "IMAGE", str(tmp_path / "pfb"), do_mfs=True, do_cube=True)
+
+    assert len(written) == 2
+    for path in written:
+        assert fits.getdata(path).ndim == 4

--- a/tests/test_restoration.py
+++ b/tests/test_restoration.py
@@ -1,0 +1,85 @@
+"""The three restored flux scales."""
+
+import numpy as np
+import pytest
+
+from spimple.utils.restoration import restore_products
+
+
+def _inputs(npix=64, ncorr=1):
+    model = np.zeros((ncorr, npix, npix))
+    model[:, npix // 2, npix // 2] = 1.0
+    residual = np.zeros((ncorr, npix, npix))
+    v = np.arange(npix) - npix // 2
+    yy, xx = np.meshgrid(v, v, indexing="ij")
+    beam = np.exp(-(xx**2 + yy**2) / (2 * (npix / 3.0) ** 2))[None]
+    beam = np.repeat(beam, ncorr, axis=0)
+    return model, residual, beam
+
+
+def test_mixed_is_the_convolved_model_plus_the_residual():
+    model, residual, beam = _inputs()
+    residual[:] = 0.25
+    gaussparf = np.tile([6.0, 4.0, 0.0], (1, 1))
+
+    out = restore_products(model, residual, beam, gaussparf, products=("k",))
+
+    # the model is a delta, so its convolution peaks at 1 for an unnormalised kernel
+    assert out["k"].shape == model.shape
+    assert out["k"][0, 32, 32] == pytest.approx(1.25, rel=1e-6)
+    assert out["k"][0, 0, 0] == pytest.approx(0.25, abs=1e-8)
+
+
+def test_intrinsic_divides_the_residual_by_the_beam_and_floors_it():
+    model, residual, beam = _inputs()
+    residual[:] = 0.25
+    gaussparf = np.tile([6.0, 4.0, 0.0], (1, 1))
+
+    out = restore_products(model, residual, beam, gaussparf, products=("i",), pb_min=0.5)
+
+    centre = out["i"][0, 32, 32]
+    assert centre == pytest.approx(1.0 + 0.25 / beam[0, 32, 32], rel=1e-6)
+    assert np.all(out["i"][0][beam[0] <= 0.5] == 0.0)
+
+
+def test_apparent_attenuates_before_convolving_not_after():
+    """(B*m) convolved is not B*(m convolved) for a spatially varying beam."""
+    npix = 64
+    model = np.zeros((1, npix, npix))
+    model[0, npix // 2 - 8, npix // 2] = 1.0
+    model[0, npix // 2 + 8, npix // 2] = 1.0
+    residual = np.zeros((1, npix, npix))
+    v = np.arange(npix) - npix // 2
+    yy, xx = np.meshgrid(v, v, indexing="ij")
+    beam = np.exp(-((xx - 20.0) ** 2 + yy**2) / (2 * 15.0**2))[None]
+    gaussparf = np.tile([6.0, 6.0, 0.0], (1, 1))
+
+    out = restore_products(model, residual, beam, gaussparf, products=("a", "k"))
+
+    naive = beam * out["k"]
+    assert not np.allclose(out["a"], naive, atol=1e-6)
+
+
+def test_residual_is_reconvolved_when_the_resolutions_differ():
+    npix = 96
+    model = np.zeros((1, npix, npix))
+    residual = np.zeros((1, npix, npix))
+    residual[0, npix // 2, npix // 2] = 1.0
+    beam = np.ones((1, npix, npix))
+    gausspari = np.tile([4.0, 4.0, 0.0], (1, 1))
+    gaussparf = np.tile([8.0, 8.0, 0.0], (1, 1))
+
+    same = restore_products(model, residual, beam, gausspari, gausspari=gausspari, products=("k",))
+    wider = restore_products(model, residual, beam, gaussparf, gausspari=gausspari, products=("k",))
+
+    # reconvolution to a coarser beam spreads the delta out
+    np.testing.assert_allclose(same["k"], residual, atol=1e-8)
+    assert wider["k"][0, npix // 2, npix // 2] < residual[0, npix // 2, npix // 2]
+    assert wider["k"].sum() > residual.sum() * 0.9
+
+
+def test_requesting_no_products_returns_an_empty_dict():
+    model, residual, beam = _inputs()
+    gaussparf = np.tile([6.0, 4.0, 0.0], (1, 1))
+
+    assert restore_products(model, residual, beam, gaussparf, products=()) == {}

--- a/tests/test_spifit.py
+++ b/tests/test_spifit.py
@@ -103,7 +103,7 @@ def test_refuses_an_uncombined_multi_partition_tree(two_pointing_fits, tmp_path)
     init(models, out, residual=residuals, overwrite=True)
 
     with pytest.raises(ValueError, match="spimple mosaic"):
-        spifit(store_name(out, "I"), str(tmp_path / "spi"), products="a")
+        spifit(store_name(out, "I"), str(tmp_path / "spi"), flux_scale="apparent", products="a")
 
 
 def test_accepts_a_mosaicked_tree(two_pointing_fits, true_alpha, tmp_path):

--- a/tests/test_spifit.py
+++ b/tests/test_spifit.py
@@ -130,3 +130,54 @@ def test_warns_when_the_beam_includes_the_n_term(pfb_tree, tmp_path, caplog):
         spifit(pfb_tree, str(tmp_path / "spi"), flux_scale="intrinsic", products="a")
 
     assert any("beam_includes_n" in record.message or "B/n" in record.message for record in caplog.records)
+
+
+def test_skips_fully_flagged_bands(pfb_tree, true_alpha, tmp_path):
+    """pfb leaves WSUM == 0 band nodes in the tree; its restore skips them.
+
+    Such a node may lack the restored product entirely, so keeping it would
+    either abort the fit or give a dead band a weight.
+    """
+    import shutil
+
+    from spimple.utils.datatree import write_node
+
+    flagged = str(tmp_path / "flagged_I.dt")
+    shutil.copytree(pfb_tree, flagged)
+    dt = open_store(flagged)
+    node = band_nodes(dt)[-1]
+    ds = dt[node].ds
+    write_node(
+        flagged,
+        node,
+        {
+            "WSUM": (("corr",), np.zeros(1, dtype=np.float32)),
+            # a dead band that restore never wrote a product for
+            "IMAGE": (("corr", "y", "x"), np.full_like(ds.IMAGE.values, np.nan)),
+        },
+        {},
+        {"corr": ["I"]},
+    )
+
+    out = str(tmp_path / "spi")
+    spifit(flagged, out, flux_scale="intrinsic", products="aI")
+
+    cube = fits.getdata(f"{out}_time0.Irec_cube.fits")
+    assert cube.shape[1] == 3, "the fully flagged band should have been dropped"
+    alpha = fits.getdata(f"{out}_time0.alpha.fits").squeeze()
+    fitted = alpha[np.isfinite(alpha)]
+    assert np.median(fitted) == pytest.approx(true_alpha, abs=0.05)
+
+
+def test_missing_product_error_names_what_is_available(pfb_tree, tmp_path):
+    """pfb restore defaults to outputs='kK', so only KIMAGE exists."""
+    import shutil
+
+    konly = str(tmp_path / "konly_I.dt")
+    shutil.copytree(pfb_tree, konly)
+    for node in band_nodes(open_store(konly)):
+        for var in ("BIMAGE", "IMAGE"):
+            shutil.rmtree(f"{konly}/{node}/{var}", ignore_errors=True)
+
+    with pytest.raises(ValueError, match="KIMAGE"):
+        spifit(konly, str(tmp_path / "spi"), flux_scale="apparent", products="a")

--- a/tests/test_spifit.py
+++ b/tests/test_spifit.py
@@ -1,97 +1,132 @@
-"""End-to-end coverage for `spimple spifit` via the core implementation.
+"""spimple spifit, the spectral index fit over a datatree."""
 
-These call the core function directly -- the same entry point the generated
-Stimela cab's `command:` targets.
-"""
+import os
 
 import numpy as np
 import pytest
 from astropy.io import fits
 
+from spimple.core.init import init, store_name
 from spimple.core.spifit import spifit
+from spimple.utils.datatree import band_nodes, open_store, write_node
 
 
-@pytest.mark.slow
-def test_recovers_the_injected_spectral_index(image_cube, residual_cube, true_alpha, tmp_path):
-    """The fixture cube is a pure power law; the fit must find its index."""
-    outname = tmp_path / "spi"
+def test_recovers_the_injected_spectral_index(pfb_tree, true_alpha, tmp_path):
+    out = str(tmp_path / "spi")
+    spifit(pfb_tree, out, flux_scale="intrinsic", products="a")
 
-    spifit(
-        images=[image_cube],
-        output_filename=str(outname),
-        residual=[residual_cube],
-        products="ai",
-        nthreads=1,
-        dont_convolve=True,
-    )
+    alpha = fits.getdata(f"{out}_time0.alpha.fits").squeeze()
+    fitted = alpha[np.isfinite(alpha)]
 
-    alpha_map = np.squeeze(fits.getdata(str(tmp_path / "spi.alpha.fits")))
-    fitted = alpha_map[np.isfinite(alpha_map) & (alpha_map != 0)]
-
-    assert fitted.size > 0, "no components were fit"
+    assert fitted.size > 0
     assert np.median(fitted) == pytest.approx(true_alpha, abs=0.05)
 
 
-@pytest.mark.slow
-def test_products_letters_select_outputs(image_cube, residual_cube, tmp_path):
-    outname = tmp_path / "prod"
+def test_apparent_scale_recovers_the_same_index(pfb_tree, true_alpha, tmp_path):
+    """Fitting the apparent image with its beam must give the intrinsic index."""
+    out = str(tmp_path / "spi_app")
+    spifit(pfb_tree, out, flux_scale="apparent", products="a")
 
-    spifit(
-        images=[image_cube],
-        output_filename=str(outname),
-        residual=[residual_cube],
-        products="ai",
-        nthreads=1,
-        dont_convolve=True,
+    alpha = fits.getdata(f"{out}_time0.alpha.fits").squeeze()
+    fitted = alpha[np.isfinite(alpha)]
+
+    assert np.median(fitted) == pytest.approx(true_alpha, abs=0.05)
+
+
+def test_unfitted_pixels_are_nan_not_zero(pfb_tree, tmp_path):
+    out = str(tmp_path / "spi")
+    spifit(pfb_tree, out, flux_scale="intrinsic", products="a")
+
+    alpha = fits.getdata(f"{out}_time0.alpha.fits").squeeze()
+
+    assert np.isnan(alpha).any()
+
+
+def test_products_letters_select_outputs(pfb_tree, tmp_path):
+    out = str(tmp_path / "spi")
+    spifit(pfb_tree, out, flux_scale="intrinsic", products="ai")
+
+    assert os.path.exists(f"{out}_time0.alpha.fits")
+    assert os.path.exists(f"{out}_time0.I0.fits")
+    assert not os.path.exists(f"{out}_time0.alpha_err.fits")
+    assert not os.path.exists(f"{out}_time0.Irec_cube.fits")
+
+
+def test_deselect_bands_reduces_the_bands_used(pfb_tree, tmp_path):
+    out = str(tmp_path / "spi")
+    spifit(pfb_tree, out, flux_scale="intrinsic", products="I", deselect_bands=[3])
+
+    cube = fits.getdata(f"{out}_time0.Irec_cube.fits")
+
+    assert cube.shape[1] == 3
+
+
+def test_output_carries_the_tree_wcs(pfb_tree, tmp_path):
+    out = str(tmp_path / "spi")
+    spifit(pfb_tree, out, flux_scale="intrinsic", products="a")
+
+    hdr = fits.getheader(f"{out}_time0.alpha.fits")
+    dt = open_store(pfb_tree)
+    ds = dt[band_nodes(dt)[0]].ds
+
+    assert hdr["CRVAL1"] == pytest.approx(np.rad2deg(ds.attrs["ra"]))
+    assert hdr["CRVAL2"] == pytest.approx(np.rad2deg(ds.attrs["dec"]))
+    assert hdr["NAXIS1"] == ds.IMAGE.shape[-1]
+    assert hdr["NAXIS2"] == ds.IMAGE.shape[-2]
+
+
+def test_refuses_a_tree_whose_bands_disagree_in_resolution(pfb_tree, tmp_path):
+    """The message must name the command that fixes it."""
+    # pfb_tree is session-scoped, so corrupt a copy -- writing PSFPARSF into the
+    # shared fixture would break every test that runs after this one
+    import shutil
+
+    corrupt = str(tmp_path / "corrupt_I.dt")
+    shutil.copytree(pfb_tree, corrupt)
+    dt = open_store(corrupt)
+    node = band_nodes(dt)[0]
+    write_node(
+        corrupt,
+        node,
+        {"PSFPARSF": (("corr", "bpar"), np.array([[99.0, 99.0, 0.0]], dtype=np.float32))},
+        {},
+        {"corr": ["I"], "bpar": ["BMAJ", "BMIN", "BPA"]},
     )
 
-    assert (tmp_path / "prod.alpha.fits").exists()
-    assert (tmp_path / "prod.I0.fits").exists()
+    with pytest.raises(ValueError, match="pfb restore"):
+        spifit(corrupt, str(tmp_path / "spi"), flux_scale="intrinsic", products="a")
 
 
-@pytest.mark.slow
-def test_i0_map_is_positive_where_fit(image_cube, residual_cube, tmp_path):
-    """I0 is a reference-frequency intensity, so every fitted pixel is positive.
+def test_refuses_an_uncombined_multi_partition_tree(two_pointing_fits, tmp_path):
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "raw")
+    init(models, out, residual=residuals, overwrite=True)
 
-    Pixels below the fitting threshold come back NaN rather than zero, so the
-    mask has to be isfinite -- `!= 0` lets NaN through, which is how an earlier
-    version of this test silently measured nothing.
-    """
-    outname = tmp_path / "i0"
-
-    spifit(
-        images=[image_cube],
-        output_filename=str(outname),
-        residual=[residual_cube],
-        products="ai",
-        nthreads=1,
-        dont_convolve=True,
-    )
-
-    i0 = np.squeeze(fits.getdata(str(tmp_path / "i0.I0.fits")))
-    fitted = i0[np.isfinite(i0) & (i0 != 0)]
-
-    assert fitted.size > 0, "no components were fit"
-    assert np.all(fitted > 0)
+    with pytest.raises(ValueError, match="spimple mosaic"):
+        spifit(store_name(out, "I"), str(tmp_path / "spi"), products="a")
 
 
-@pytest.mark.slow
-def test_max_dr_threshold_used_without_residual(image_cube, tmp_path):
-    """With no residual the threshold comes from maxDR instead of the rms.
+def test_accepts_a_mosaicked_tree(two_pointing_fits, true_alpha, tmp_path):
+    from spimple.core.mosaic import mosaic
 
-    Task 9 renames this parameter to max_dr; this call site is deliberately
-    written against the current name so the rename fails loudly if applied
-    inconsistently.
-    """
-    outname = tmp_path / "nodr"
+    models, residuals = two_pointing_fits
+    out = str(tmp_path / "mos")
+    init(models, out, residual=residuals, overwrite=True)
+    mosaic(store_name(out, "I"), fits_outputs="")
 
-    spifit(
-        images=[image_cube],
-        output_filename=str(outname),
-        products="a",
-        nthreads=1,
-        dont_convolve=True,
-        max_dr=100,
-    )
+    spi = str(tmp_path / "spi")
+    spifit(store_name(out, "I"), spi, flux_scale="intrinsic", products="a")
 
-    assert (tmp_path / "nodr.alpha.fits").exists()
+    alpha = fits.getdata(f"{spi}_time0.alpha.fits").squeeze()
+    fitted = alpha[np.isfinite(alpha)]
+    assert fitted.size > 0
+    assert np.median(fitted) == pytest.approx(true_alpha, abs=0.15)
+
+
+def test_warns_when_the_beam_includes_the_n_term(pfb_tree, tmp_path, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="spimple.SPIFIT"):
+        spifit(pfb_tree, str(tmp_path / "spi"), flux_scale="intrinsic", products="a")
+
+    assert any("beam_includes_n" in record.message or "B/n" in record.message for record in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -2916,6 +2916,8 @@ full = [
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "xarray", version = "2025.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "zarr", version = "2.18.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "zarr", version = "3.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -2942,6 +2944,7 @@ requires-dist = [
     { name = "reproject", marker = "extra == 'full'" },
     { name = "scipy", marker = "extra == 'full'" },
     { name = "xarray", marker = "extra == 'full'" },
+    { name = "zarr", marker = "extra == 'full'" },
 ]
 provides-extras = ["full"]
 


### PR DESCRIPTION
Closes #50.

`spifit` and `mosaic` now operate on an `xarray.DataTree` store laid out exactly as
`pfb imager` writes it, so **a tree produced by pfb-imaging is consumed directly, with no
ingest step**. FITS input from any other imager is ingested into the same layout by a new
`spimple init`, which subsumes `imconv`'s convolution and `mosaic`'s reprojection.

## The two workflows

```bash
# from pfb-imaging: no ingest step at all
pfb restore --output-filename out --gausspar 8.0 6.4 0.0
spimple spifit --store out_I.dt --output-filename spi

# from any other imager
spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
             --output-filename out --beam-model JimBeam
spimple mosaic --store out_I.dt          # only if the input had several pointings
spimple spifit --store out_I.dt --output-filename spi
```

`pfb imager` mosaics in visibility space, so its band nodes arrive already populated —
**`spimple mosaic` is never part of a pfb workflow**, and it refuses such a tree with a
message saying so.

## Command surface

| Command | Change |
|---|---|
| `spimple init` | **New.** Partitions by phase centre and grid, bands by frequency, homogenises resolution, attaches a beam, reprojects partitions onto a union grid. |
| `spimple mosaic` | **Rewritten.** Takes `--store`; combines image-space partitions into band mean images. |
| `spimple spifit` | **Rewritten.** Takes `--store`; reads band nodes and fits. |
| `spimple binterp` | Unchanged. Still FITS in, FITS out, and the only home of the MS-derived DDE beam path. Its output cube is now a valid `init --beam-model`. |
| `spimple imconv` | **Deprecated**, warns on use. Removal in a follow-up PR, as agreed. |

## Design decisions

Recorded as D11–D16 in `docs/wiki/design-decisions.md`; the store layout and its invariants
get their own page, `docs/wiki/datatree-contract.md`.

- **No pfb-imaging dependency.** `pfb_imaging.utils.misc` imports jax, numba, numexpr,
  daskms and skimage at module scope, so borrowing `convolve2gaussres` would drag in
  `pfb-imaging[full]`. spimple ports what it needs and owns the schema in
  `utils/datatree.py`, which is the single place the cross-repo contract can drift from.
- **`init` homogenises, `mosaic` combines.** Convolution lives in one place. `spifit` and
  `mosaic` both assume an already-homogenised tree and name the fix when it isn't one.
- **`init` writes the restore-named products** `IMAGE`/`BIMAGE`/`KIMAGE` + `PSFPARSF`, so
  `spifit` needs no origin-specific branching. Native-resolution `MODEL`/`RESIDUAL` are
  never copied into the store — the input FITS is already that archive.
- **The band beam after mosaicking is `sum B^2 / sum B`**, the beam-weighted mean, which is
  the reduction consistent with the `B^2`-weighted solve that produced `IMAGE`. This
  deliberately differs from pfb's WSUM-weighted band beam.
- **The mosaic solve is direct, not CG.** `(sum_p mask_p B_p^2 + eta) S = sum_p B_p A_p` is
  diagonal, so the exact answer is one division; CG was only iterating towards it.
  `conjugate_gradient` is kept for a future non-diagonal formulation and pinned against the
  direct solve by a test.

## Bugs found, all pre-existing

1. **`Gaussian2D` produced kernels 8.51 % too wide.** The exponent used `fwhm_conv` where
   the FWHM parametrisation needs `4 ln2`. Every `imconv`/`spifit` convolution to date
   homogenised to a resolution 8.51 % coarser than requested. Verified against pfb's
   `gaussian2d`, which matches to 1.7e-16 once corrected.
2. **`set_wcs` read the reference frequency one channel too high** — it indexed the
   frequency array with the one-based `CRPIX3`. `CRVAL3` was wrong on every multi-channel
   cube, and a **two-channel cube raised `IndexError`**, which is `spifit`'s documented
   minimum. It survived because the only caller passing an array of frequencies sat on the
   end-to-end mosaic path the tests skipped.
3. **`convolve2gaussres` tested `gausspari in [None, ()]`** — an elementwise comparison
   that raises for a numpy array. Latent because every legacy caller passed tuples.
4. **`ref_wcs.array_shape` was unpacked in both orders** across two modules, invisible only
   for square outputs. Both call sites are gone.

## A regression introduced and reverted — please read

Fixing (1) I also changed `Gaussian2D`'s *support* from `nsigma * FWHM` to `nsigma * sigma`,
matching both its docstring and pfb. That broke the deconvolution path: a source at `x=20`
rendered at `x=24`.

`convolve2gaussres` divides by the kernel's transform when `gausspari` is given. A
Gaussian's transform decays to ~1e-14 by Nyquist; a 5-sigma truncation leaves a step of
3.7e-6 of peak whose spectral ripple swamps that floor, and the division amplifies it into
ringing that moves the peak to twice its offset from image centre. At 5 FWHM the step is
~4e-31 and the division is clean. Reverted, with the reasoning in the code and a post-mortem
in the wiki.

**The same latent issue exists in pfb-imaging** — `gaussian2d` uses `nsigma * sigma_maj`
and `restore_products` performs the identical division. Reported as ratt-ru/pfb-imaging#312,
with the displacement measured at every image size from 32 to 1024 px.

Worth noting: the suite was green throughout. Only running `init` end-to-end exposed it,
because nothing covered `gausspari != gaussparf`. That gap is now pinned by
`test_convolve2gaussres_preserves_position_when_deconvolving`.

## Testing

185 passed, 1 skipped. The skip is the pre-existing `binterp` FITS-beam path; the old
`mosaic` skip is gone because `mosaic` no longer needs a `.bds.zarr` — the beam is a stored
variable.

New coverage worth calling out:

- **Orientation.** A bright pixel at an asymmetric index on a non-square raster must survive
  the tree round-trip and land where `world_to_pixel` predicts. It is the only test that
  fails when an image is transposed; everything else passes.
- **Schema contract.** A synthetic pfb-shaped `.dt` fixture, built to the layout in
  pfb-imaging's `imager-pipeline.md` and citing the commit it was checked against, lets
  every consumer be tested against a pfb-origin tree without pfb-imaging installed.
- **Deconvolution positional fidelity**, the gap that hid the regression above.
- **End-to-end**: a two-pointing synthetic dataset with a JimBeam, run through
  `init -> mosaic -> spifit` from the shell, recovers **alpha = -0.6999 against a true
  -0.7000** over 3278 fitted pixels.

## Breaking changes

- `spifit` and `mosaic` take `--store` instead of FITS. Convolution, beams, frequencies and
  weights now come from the tree, so `--psf-pars`, `--dont-convolve`,
  `--add-convolved-residuals`, `--channel-freqs`, `--channel-weights-keyword`, `--ms`,
  `--beam-model`, `--band`, `--sparsify-time`, `--corr-type` and the old mosaic options are
  gone. `--flux-scale` and `--timeid` are new.
- Array order on the tree path is (Y, X).
- `Gaussian2D` and `set_wcs` output changes per the bugs above.
- `imconv` warns.
- `zarr` is added to the `full` extra, deliberately unpinned: zarr 3 needs Python 3.11 and
  CI still tests 3.10. The DataTree round-trip was verified working on 3.10 with zarr
  2.18.3, so both resolutions are supported.

## Deferred, deliberately

- **Ray is not wired up.** Both commands run serially and accept `--nworkers` without acting
  on it. If `init` proves slow on real cubes, parallelising per partition is the change.
- **The `.bds.zarr` beam backend is unverified against a real file.** No meerkat-beams
  dataset was available, so the fixture only pins the reader against our own writer. In the
  wiki's known-defects list; run it against a real store before relying on it.
- **pfb's `BEAM` is `B/n`, not the bare primary beam.** `spifit` logs a warning naming the
  correction rather than absorbing it; the fix lands in a follow-up PR, as agreed.
- **Removing `imconv`**, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
