### PR TITLE
feat!: weight the intrinsic spectral index fit by the beam, drop --flux-scale mixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ consumed directly. FITS input from any other imager is ingested into the same la
 
 ```bash
 # images from pfb-imaging: no ingest step at all
-pfb restore --output-filename out --gausspar 0.00222 0.00178 0.0  # degrees: 8.0 x 6.4 arcsec
-spimple spifit --store out_I.dt --flux-scale mixed --output-filename spi
+pfb restore --output-filename out --gausspar 0.00222 0.00178 0.0 --outputs iI  # degrees: 8.0 x 6.4 arcsec
+spimple spifit --store out_I.dt --flux-scale intrinsic --output-filename spi
 
 # FITS from any other imager
 spimple init --images "field*-model.fits" --residual "field*-residual.fits" \
@@ -29,10 +29,11 @@ spimple mosaic --store out_I.dt            # only if the input had several point
 spimple spifit --store out_I.dt --flux-scale apparent --output-filename spi
 ```
 
-`--flux-scale` is required and has no default: the three scales mean different things,
-and which products a tree even holds depends on how it was made. `pfb restore` defaults to
-`--outputs kK`, which writes `KIMAGE` only — hence `--flux-scale mixed` above. Ask it for
-`--outputs kKaA` if you want the apparent scale too.
+`--flux-scale` is required and has no default: the two scales mean different things, and
+which products a tree even holds depends on how it was made. Watch out for `pfb restore`'s
+default of `--outputs kK`, which writes `KIMAGE` only: that product is an intrinsic model
+plus an apparent residual, so it is not fittable and `spifit` refuses it. Ask restore for
+`--outputs i` or `--outputs a`, as above.
 
 `pfb imager` mosaics in visibility space, so its band nodes arrive already populated —
 **`spimple mosaic` is never part of a pfb workflow.**
@@ -109,10 +110,11 @@ spimple spifit \
 named `<output-filename>_time{t}.<product>.fits`. Unfitted pixels are `NaN`, not zero.
 
 `--flux-scale` is **required** and picks which stored product to fit: `apparent`
-(`BIMAGE`, fitted together with the beam), `intrinsic` (`IMAGE`, already beam-corrected)
-or `mixed` (`KIMAGE`). All three pass the band's mean `BEAM` map to the fitter as the
-first-order response; `mixed` is an intrinsic model plus an apparent residual, so its beam
-handling is approximate by construction. The tree must already be at one resolution —
+(`BIMAGE`, fitted with the beam in the model) or `intrinsic` (`IMAGE`, already
+beam-corrected, fitted with `BEAM²` weights). The two are the same weighted least-squares
+problem written two ways, so they agree to machine precision on a self-consistent tree —
+run both as a check on the tree's products. `KIMAGE` is not fittable and there is no
+`mixed` scale; see the note above. The tree must already be at one resolution —
 `spimple init` or `pfb restore --gausspar` does that.
 
 ### Interpolate a primary beam
@@ -137,7 +139,12 @@ comma-separated string and accept glob patterns.
 - `spifit` and `mosaic` take `--store`, a datatree, instead of FITS images. Their
   FITS-specific options are gone; convolution, beams, frequencies and weights now come
   from the tree.
-- `spifit --flux-scale` is required, with no default.
+- `spifit --flux-scale` is required, with no default, and no longer accepts `mixed`.
+  `KIMAGE` mixes an intrinsic model with an apparent residual, so fitting it biased the
+  flux towards the field edge; `spifit` now errors out naming the `pfb restore` rerun.
+- `spifit --flux-scale intrinsic` now weights each pixel by `BEAM²` instead of fitting
+  with unity weights, which makes it agree with `--flux-scale apparent` exactly. Fitted
+  spectral indices and their errors change wherever the beam varies across the band.
 - `imconv` is deprecated and warns on use. It will be removed in a following release.
 - `Gaussian2D` was producing kernels 8.51 % too wide, so every convolution now homogenises
   to the resolution actually requested. Output changes accordingly.

--- a/docs/wiki/datatree-contract.md
+++ b/docs/wiki/datatree-contract.md
@@ -3,8 +3,8 @@ type: reference
 title: The DataTree contract with pfb-imaging
 description: The store layout spimple reads and writes, its invariants, and how a spimple tree differs from a pfb-imaging one.
 tags: [datatree, zarr, pfb-imaging, interop, conventions]
-timestamp: 2026-08-13
-last_verified_commit: b7bfbc4
+timestamp: 2026-08-15
+last_verified_commit: af2d642
 ---
 
 # The DataTree contract with pfb-imaging
@@ -83,7 +83,7 @@ spimple tree could silently diverge from a pfb one.
 |---|---|
 | **Axis order** | Every image variable is `(corr, y, x)`. No transposes on the tree path; `save_fits` is called with `yx_order=True`. The only test that catches a violation is the orientation test in `tests/test_render.py` — everything else passes while transposed. |
 | **Resolution units** | `PSFPARSN`/`PSFPARSF` are `(emaj, emin, pa)` in **pixels, pixels, radians**, matching pfb. FITS `BMAJ`/`BMIN` (degrees) are divided by `cell_deg`; `BPA` goes through `deg2rad`. `set_wcs` converts back with `unit2deg=cell_x`. |
-| **Flux scale** | `IMAGE` intrinsic, `BIMAGE` apparent, `KIMAGE` mixed — pfb's three scales, same names (`PRODUCT_VARS`). All are Jy/beam at `PSFPARSF`, already normalised. |
+| **Flux scale** | `IMAGE` intrinsic, `BIMAGE` apparent, `KIMAGE` mixed — pfb's three scales, same names (`PRODUCT_VARS`). All are Jy/beam at `PSFPARSF`, already normalised. `spifit` fits `IMAGE` or `BIMAGE` only; `KIMAGE` mixes scales and is rejected (D18). |
 | **No native-resolution copy** | spimple never persists a native `MODEL`/`RESIDUAL`: the input FITS is the archive. pfb's "divide the stored `RESIDUAL` by `WSUM`" step therefore has no spimple analogue. |
 | **Beam semantics** | On a spimple tree `BEAM` is the bare primary beam and `beam_includes_n` is False. On a pfb tree `BEAM` is `B/n` with the flag True — see design-decisions.md. |
 | **Grid** | Every partition under a band node is on the union grid. Native-grid arrays are never stored: `reproject_interp` conserves surface brightness, not flux, so a Jy/pixel model would not survive it. Convolving first makes everything Jy/beam, after which reprojection is sound. |

--- a/docs/wiki/design-decisions.md
+++ b/docs/wiki/design-decisions.md
@@ -3,8 +3,8 @@ type: reference
 title: Design decisions and known defects
 description: The decision ledger for the hip-cargo port, plus the defects diagnosed but not fixed.
 tags: [architecture, decisions, known-issues]
-timestamp: 2026-08-13
-last_verified_commit: b7bfbc4
+timestamp: 2026-08-15
+last_verified_commit: af2d642
 ---
 
 # Design decisions and known defects
@@ -46,6 +46,8 @@ an org package inherits its repository's access.)
 | D14 | `init` writes the restore-named products `IMAGE`/`BIMAGE`/`KIMAGE` plus `PSFPARSF`, and never persists a native-resolution `MODEL`/`RESIDUAL`. | Identical variable names to `pfb restore` means `spifit` needs no origin-specific branching. The input FITS is already the archive of the native-resolution data, so copying it into the store buys nothing. |
 | D15 | The band beam after mosaicking is `sum B^2 / sum B`, the beam-weighted mean — deliberately not pfb's WSUM-weighted mean. | It is the reduction consistent with the `B^2`-weighted solve that produced `IMAGE`, so `BEAM * IMAGE` is exactly the beam-weighted mean apparent image. pfb's D28 warns specifically against reducing a quantity and its weighting by different rules at the same level. Reduces to `B` where partitions agree and to `B_p` where only `p` covers. |
 | D16 | The mosaic normal equations are solved directly, not by conjugate gradient. | `(sum_p mask_p B_p^2 + eta) S = sum_p B_p A_p` is diagonal — purely elementwise — so the exact solution is one division and CG only iterates towards it. `conjugate_gradient` is retained for a future non-diagonal formulation and pinned against the direct solve by a test. `--cg-max-iter`/`--cg-tol` were dropped; `--eta` stays. |
+| D17 | `fit_spi_components` is vendored into `utils/fit_spi.py` and its weights carry a component axis, so `--flux-scale intrinsic` weights by `B^2`. | Image-plane noise is flat in the *apparent* image, so `IMAGE = BIMAGE / BEAM` has variance `sigma_v^2 / B(v,p)^2` and its inverse-variance weight is `B(v,p)^2 / sigma_v^2`. The beam narrows with frequency, so that weight does not factorise into a `(chan,)` vector — africanus's signature cannot express it, which is why the intrinsic path previously fitted with unity weights. With `B^2` weights the intrinsic fit is *algebraically the same normal equations* as the apparent fit with the beam in the model (`sum_v w_v (d_app - B_v M_v)^2 = sum_v (w_v B_v^2)(d_int - M_v)^2`), so the two scales become a consistency check on `BIMAGE`, `IMAGE` and `BEAM` agreeing in the tree rather than two differently-weighted estimators. Pinned to machine precision in `tests/test_fit_spi.py` and end-to-end in `test_intrinsic_and_apparent_scales_give_the_same_alpha`. |
+| D18 | `spifit` has no `--flux-scale mixed`; `KIMAGE` is not fittable and asking for it, or handing over a tree carrying only it, is an early error naming the `pfb restore` rerun. | `KIMAGE` is an intrinsic model plus an *apparent* residual, so its signal and its noise sit on different flux scales and no single beam relates them. Fitting it with the beam in the model — what the removed `mixed` path did — drove `I0` up roughly as `1/B` towards the field edge; fitting it without one mis-weights the residual instead. There is no correct setting, only two wrong ones, so the option is gone rather than fixed. It has to fail early and loudly because `pfb restore` defaults to `--outputs kK`, which writes `KIMAGE` *only*, so the tree a user most likely has is exactly the one that cannot be fitted. `init` and `mosaic` still carry `KIMAGE` through the tree (D14); it is only the fit that refuses it. |
 
 
 ## Bugs found and fixed during the DataTree refactor
@@ -186,6 +188,17 @@ skip in `tests/test_mosaic.py`, which does cover `mosaic_info`.
 
 `spifit` accepts `channel_weights_keyword` (default `WSCIMWG`) but the residual-weighting
 branch hardcodes `WSCVWSUM`. The option has no effect there.
+
+### The `B^2` fit weight ignores how many pointings covered a pixel
+
+For a band mosaicked from overlapping pointings the true inverse variance of `IMAGE` is
+`SPATIALWGT = sum_p B_p^2 + eta`, not `BEAM^2 = (sum_p B_p^2 / sum_p B_p)^2`. Two
+identical overlapping pointings give `SPATIALWGT = 2 B^2` but `BEAM^2 = B^2`, so the
+overlap is under-weighted by exactly the factor the mosaic bought. `BEAM^2` is used
+anyway because it is what makes the intrinsic and apparent fits identical (D17), and
+because the apparent path shares the same implicit flat-noise assumption — moving to
+`SPATIALWGT` means changing both paths together. The two coincide for single-pointing
+bands, which is every tree the tests cover.
 
 ### Stray `print()` calls in `utils/beam.py`
 

--- a/src/spimple/cabs/spifit.yml
+++ b/src/spimple/cabs/spifit.yml
@@ -28,12 +28,10 @@ cabs:
         info:
           Flux scale to fit.
           Apparent uses BIMAGE.
-          Intrinsic uses IMAGE.
-          Mixed uses KIMAGE
+          Intrinsic uses IMAGE
         choices:
         - apparent
         - intrinsic
-        - mixed
         required: true
         policies:
           positional: true

--- a/src/spimple/cli/spifit.py
+++ b/src/spimple/cli/spifit.py
@@ -44,10 +44,10 @@ def spifit(
         ),
     ],
     flux_scale: Annotated[
-        Literal["apparent", "intrinsic", "mixed"],
+        Literal["apparent", "intrinsic"],
         typer.Option(
             ...,
-            help="Flux scale to fit. Apparent uses BIMAGE. Intrinsic uses IMAGE. Mixed uses KIMAGE",
+            help="Flux scale to fit. Apparent uses BIMAGE. Intrinsic uses IMAGE",
         ),
     ],
     products: Annotated[

--- a/src/spimple/core/spifit.py
+++ b/src/spimple/core/spifit.py
@@ -17,7 +17,14 @@ from spimple.utils.logging import get_logger, log_options
 
 log = get_logger("SPIFIT")
 
-_SCALES = {"apparent": "a", "intrinsic": "i", "mixed": "k"}
+_SCALES = {"apparent": "a", "intrinsic": "i"}
+
+# What to tell a user who reaches for KIMAGE, whether by asking for the removed
+# mixed scale or by handing over a tree that carries nothing else.
+_RESTORE_HINT = (
+    "rerun pfb restore with --outputs a, which writes BIMAGE for --flux-scale apparent, "
+    "or --outputs i, which writes IMAGE for --flux-scale intrinsic"
+)
 
 
 def spifit(
@@ -41,18 +48,26 @@ def spifit(
     or by pfb restore with a target resolution. Multi partition trees written by
     spimple init must be combined with spimple mosaic first.
 
-    flux_scale has no default deliberately: the three scales carry different
+    flux_scale has no default deliberately: the two scales carry different
     physical meanings and which products a tree even holds depends on how it was
     made, so the caller states which one they are fitting rather than having one
-    chosen for them.
+    chosen for them. KIMAGE is not fittable at all -- it is an intrinsic model
+    plus an apparent residual, so no single beam relates its signal to its noise.
     """
     log_options(log, **locals())
 
     import dask.array as da
-    from africanus.model.spi.dask import fit_spi_components
+
+    from spimple.utils.fit_spi import fit_spi_components
 
     if not nthreads:
         nthreads = multiprocessing.cpu_count()
+    if flux_scale == "mixed":
+        raise ValueError(
+            "--flux-scale mixed was removed. KIMAGE is an intrinsic model plus an apparent residual, "
+            "so its signal and its noise sit on different flux scales and fitting it biases the flux "
+            f"towards the field edge. Fit a single-scale product instead: {_RESTORE_HINT}"
+        )
     if flux_scale not in _SCALES:
         raise ValueError(f"Unknown flux-scale {flux_scale}, expected one of {sorted(_SCALES)}")
     column = PRODUCT_VARS[_SCALES[flux_scale]]
@@ -88,17 +103,21 @@ def spifit(
         for node in keep:
             if column not in dt[node].ds:
                 available = sorted(v for v in PRODUCT_VARS.values() if v in dt[node].ds)
+                fittable = [
+                    (scale, name)
+                    for scale, name in (("apparent", "BIMAGE"), ("intrinsic", "IMAGE"))
+                    if name in available
+                ]
                 if partition_nodes(dt, node) and not available:
                     hint = "run spimple mosaic to combine its partitions"
+                elif fittable:
+                    scales = ", ".join(f"{name} for --flux-scale {scale}" for scale, name in fittable)
+                    hint = f"the tree carries {scales}"
                 elif available:
-                    scales = ", ".join(
-                        f"{name} for --flux-scale {scale}"
-                        for scale, name in (("apparent", "BIMAGE"), ("intrinsic", "IMAGE"), ("mixed", "KIMAGE"))
-                        if name in available
-                    )
+                    # KIMAGE only, which pfb restore's default --outputs kK gives
                     hint = (
-                        f"the tree carries {scales}. Note pfb restore defaults to --outputs kK, "
-                        "which writes KIMAGE only"
+                        f"the tree carries {', '.join(available)} only, which mixes flux scales and cannot be "
+                        f"fitted. Note pfb restore defaults to --outputs kK; {_RESTORE_HINT}"
                     )
                 else:
                     hint = "the tree carries no restored product at all"
@@ -167,6 +186,8 @@ def spifit(
         # the fit runs on Stokes I; other correlations are carried in the header only
         image = cube[:, 0]
         pbeam = beam[:, 0]
+        # the intrinsic image is already beam corrected, so the beam leaves the
+        # model and reappears in the weights below
         fit_beam = np.ones_like(pbeam) if flux_scale == "intrinsic" else pbeam
 
         masked = np.where(pbeam > pb_min, image, np.nan)
@@ -182,10 +203,24 @@ def spifit(
 
         ncomps = fitcube.shape[0]
         cchunks = max(1, ncomps // nthreads)
+
+        # Image plane noise is flat in the apparent image, so IMAGE = BIMAGE /
+        # BEAM has variance sigma_v ** 2 / B(v, p) ** 2 and its inverse variance
+        # weight carries B ** 2. That weight depends on position as well as
+        # frequency, because the beam narrows with frequency, so it needs the
+        # component axis. Weighting this way makes the intrinsic fit algebraically
+        # identical to the apparent one, which is what makes the two a
+        # consistency check on IMAGE, BIMAGE and BEAM agreeing in the tree.
+        if flux_scale == "intrinsic":
+            pbeam_comps = pbeam[:, maskindices[:, 0], maskindices[:, 1]].T
+            fit_weights = da.from_array((weights[None, :] * pbeam_comps**2).astype(np.float64), chunks=(cchunks, nband))
+        else:
+            fit_weights = da.from_array(weights.astype(np.float64), chunks=(nband,))
+
         log.info("Fitting %s components", ncomps)
         alpha, alpha_err, i0, i0_err = fit_spi_components(
             da.from_array(fitcube.astype(np.float64), chunks=(cchunks, nband)),
-            da.from_array(weights.astype(np.float64), chunks=(nband,)),
+            fit_weights,
             da.from_array(freqs.astype(np.float64), chunks=(nband,)),
             np.float64(nu_ref),
             beam=da.from_array(beam_comps.astype(np.float64), chunks=(cchunks, nband)),

--- a/src/spimple/utils/fit_spi.py
+++ b/src/spimple/utils/fit_spi.py
@@ -1,3 +1,27 @@
+"""Weighted least-squares fit of a spectral index model.
+
+Vendored from ``africanus.model.spi`` so the weights can be per component as
+well as per channel. The model is
+
+    I(nu) = A(nu) I0 (nu / nu0) ** alpha
+
+and the kernel minimises ``sum_v w[comp, v] (data[comp, v] - model[v]) ** 2``
+by Gauss-Newton.
+
+Why the weights need a component axis: image plane noise is flat in the
+*apparent* image, so the intrinsic image ``IMAGE = BIMAGE / BEAM`` has variance
+``sigma_v ** 2 / B(v, p) ** 2``. The inverse variance weight is therefore
+``B(v, p) ** 2 / sigma_v ** 2``, which depends on both position and frequency
+because the beam narrows with frequency. It does not factorise, so a
+``(chan,)`` weight vector cannot express it. With those weights, fitting the
+intrinsic image is algebraically identical to fitting the apparent image with
+the beam in the model:
+
+    sum_v w_v (d_app - B_v M_v) ** 2 = sum_v (w_v B_v ** 2) (d_int - M_v) ** 2
+
+which ``tests/test_fit_spi.py`` pins to machine precision.
+"""
+
 import numpy as np
 from africanus.util.numba import jit
 from dask.array.core import blockwise
@@ -13,6 +37,7 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out, jac, beam, ncomps
         alphak = out[0, comp]
         i0k = out[2, comp]
         b = beam[comp]
+        wgt = weights[comp]
         while eps > tol and k < maxiter:
             alphap = alphak
             i0p = i0k
@@ -27,12 +52,12 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out, jac, beam, ncomps
             jr0 = 0.0
             jr1 = 0.0
             for v in range(nfreqs):
-                lik += residual[v] * weights[v] * residual[v]
-                jr0 += jac[0, v] * weights[v] * residual[v]
-                jr1 += jac[1, v] * weights[v] * residual[v]
-                hess00 += jac[0, v] * weights[v] * jac[0, v]
-                hess01 += jac[0, v] * weights[v] * jac[1, v]
-                hess11 += jac[1, v] * weights[v] * jac[1, v]
+                lik += residual[v] * wgt[v] * residual[v]
+                jr0 += jac[0, v] * wgt[v] * residual[v]
+                jr1 += jac[1, v] * wgt[v] * residual[v]
+                hess00 += jac[0, v] * wgt[v] * jac[0, v]
+                hess01 += jac[0, v] * wgt[v] * jac[1, v]
+                hess11 += jac[1, v] * wgt[v] * jac[1, v]
             det = np.maximum(hess00 * hess11 - hess01**2, mindet)
             alphak = alphap + (hess11 * jr0 - hess01 * jr1) / det
             i0k = i0p + (-hess01 * jr0 + hess00 * jr1) / det
@@ -45,10 +70,50 @@ def _fit_spi_components_impl(data, weights, freqs, freq0, out, jac, beam, ncomps
     return out
 
 
-def fit_spi_components_np(data, weights, freqs, freq0, alphai=None, I0i=None, beam=None, tol=1e-4, maxiter=100):
+def fit_spi_components_np(
+    data: np.ndarray,
+    weights: np.ndarray,
+    freqs: np.ndarray,
+    freq0: float,
+    alphai: np.ndarray | None = None,
+    I0i: np.ndarray | None = None,
+    beam: np.ndarray | None = None,
+    tol: float = 1e-4,
+    maxiter: int = 100,
+) -> np.ndarray:
+    """Fit alpha and I0 per component.
+
+    Args:
+        data: (comps, chan) spectrum per component.
+        weights: (chan,) or (comps, chan) inverse variance. A 1d array is
+            broadcast over components.
+        freqs: (chan,) frequencies.
+        freq0: reference frequency.
+        alphai: (comps,) initial alphas, defaulting to -0.7.
+        I0i: (comps,) initial intensities, defaulting to the band nearest freq0.
+        beam: (comps, chan) attenuation applied to the model, defaulting to one.
+        tol: absolute convergence tolerance on alpha and I0.
+        maxiter: Gauss-Newton iteration cap.
+
+    Returns:
+        (4, comps) array of [alphas, alphavars, I0s, I0vars]. The variances are
+        rescaled by the reduced chi squared, so only the relative scale of
+        ``weights`` matters.
+
+    Raises:
+        ValueError: if data is not float32 or float64, or weights does not
+            broadcast onto data.
+    """
     ncomps, nfreqs = data.shape
     if beam is None:
         beam = np.ones(data.shape, data.dtype)
+    weights = np.asarray(weights, dtype=data.dtype)
+    if weights.ndim == 1:
+        weights = np.broadcast_to(weights, data.shape)
+    if weights.shape != data.shape:
+        raise ValueError(f"weights of shape {weights.shape} does not match data of shape {data.shape}")
+    # numba indexes this row by row; a broadcast view has a zero stride
+    weights = np.ascontiguousarray(weights)
     jac = np.zeros((2, nfreqs), dtype=data.dtype)
     out = np.zeros((4, ncomps), dtype=data.dtype)
     if alphai is not None:
@@ -101,14 +166,18 @@ def _fit_spi_components_wrapper(data, weights, freqs, freq0, alphai, I0i, beam, 
 
 
 def fit_spi_components(data, weights, freqs, freq0, alphai=None, I0i=None, beam=None, tol=1e-5, maxiter=100):
-    """Dask wrapper fit_spi_components function"""
+    """Dask wrapper for :func:`fit_spi_components_np`.
+
+    ``weights`` may be chunked as ``(chan,)`` or, to weight each component
+    separately, as ``(comps, chan)`` matching ``data``.
+    """
     return blockwise(
         _fit_spi_components_wrapper,
         ("vars", "comps"),
         data,
         ("comps", "chan"),
         weights,
-        ("chan",),
+        ("comps", "chan") if weights.ndim == 2 else ("chan",),
         freqs,
         ("chan",),
         freq0,

--- a/src/spimple/utils/fit_spi.py
+++ b/src/spimple/utils/fit_spi.py
@@ -1,0 +1,128 @@
+import numpy as np
+from africanus.util.numba import jit
+from dask.array.core import blockwise
+
+
+@jit(nopython=True, nogil=True, cache=True)
+def _fit_spi_components_impl(data, weights, freqs, freq0, out, jac, beam, ncomps, nfreqs, tol, maxiter, mindet):
+    w = freqs / freq0
+    dof = np.maximum(w.size - 2, 1)
+    for comp in range(ncomps):
+        eps = 1.0
+        k = 0
+        alphak = out[0, comp]
+        i0k = out[2, comp]
+        b = beam[comp]
+        while eps > tol and k < maxiter:
+            alphap = alphak
+            i0p = i0k
+            jac[1, :] = b * w**alphak
+            model = i0k * jac[1, :]
+            jac[0, :] = model * np.log(w)
+            residual = data[comp] - model
+            lik = 0.0
+            hess00 = 0.0
+            hess01 = 0.0
+            hess11 = 0.0
+            jr0 = 0.0
+            jr1 = 0.0
+            for v in range(nfreqs):
+                lik += residual[v] * weights[v] * residual[v]
+                jr0 += jac[0, v] * weights[v] * residual[v]
+                jr1 += jac[1, v] * weights[v] * residual[v]
+                hess00 += jac[0, v] * weights[v] * jac[0, v]
+                hess01 += jac[0, v] * weights[v] * jac[1, v]
+                hess11 += jac[1, v] * weights[v] * jac[1, v]
+            det = np.maximum(hess00 * hess11 - hess01**2, mindet)
+            alphak = alphap + (hess11 * jr0 - hess01 * jr1) / det
+            i0k = i0p + (-hess01 * jr0 + hess00 * jr1) / det
+            eps = np.maximum(np.abs(alphak - alphap), np.abs(i0k - i0p))
+            k += 1
+        out[0, comp] = alphak
+        out[1, comp] = hess11 / det * lik / dof
+        out[2, comp] = i0k
+        out[3, comp] = hess00 / det * lik / dof
+    return out
+
+
+def fit_spi_components_np(data, weights, freqs, freq0, alphai=None, I0i=None, beam=None, tol=1e-4, maxiter=100):
+    ncomps, nfreqs = data.shape
+    if beam is None:
+        beam = np.ones(data.shape, data.dtype)
+    jac = np.zeros((2, nfreqs), dtype=data.dtype)
+    out = np.zeros((4, ncomps), dtype=data.dtype)
+    if alphai is not None:
+        out[0, :] = alphai
+    else:
+        out[0, :] = -0.7 * np.ones(ncomps, dtype=data.dtype)
+    if I0i is not None:
+        out[2, :] = I0i
+    else:
+        tmp = np.abs(freqs - freq0)
+        ref_freq_idx = np.argwhere(tmp == tmp.min()).squeeze()
+        if np.size(ref_freq_idx) > 1:
+            ref_freq_idx = ref_freq_idx.min()
+        out[2, :] = data[:, ref_freq_idx] / beam[:, ref_freq_idx]
+    if data.dtype == np.float64:
+        mindet = 1e-12
+    elif data.dtype == np.float32:
+        mindet = 1e-5
+    else:
+        raise ValueError("Unsupported data type. Must be float32 of float64.")
+
+    return _fit_spi_components_impl(
+        data,
+        weights,
+        freqs,
+        freq0,
+        out,
+        jac,
+        beam,
+        ncomps,
+        nfreqs,
+        tol,
+        maxiter,
+        mindet,
+    )
+
+
+def _fit_spi_components_wrapper(data, weights, freqs, freq0, alphai, I0i, beam, tol, maxiter):
+    return fit_spi_components_np(
+        data[0],
+        weights[0],
+        freqs[0],
+        freq0,
+        alphai,
+        I0i,
+        beam[0] if beam is not None else beam,
+        tol=tol,
+        maxiter=maxiter,
+    )
+
+
+def fit_spi_components(data, weights, freqs, freq0, alphai=None, I0i=None, beam=None, tol=1e-5, maxiter=100):
+    """Dask wrapper fit_spi_components function"""
+    return blockwise(
+        _fit_spi_components_wrapper,
+        ("vars", "comps"),
+        data,
+        ("comps", "chan"),
+        weights,
+        ("chan",),
+        freqs,
+        ("chan",),
+        freq0,
+        None,
+        alphai,
+        ("comps",) if alphai is not None else None,
+        I0i,
+        ("comps",) if I0i is not None else None,
+        beam,
+        ("comps", "chan") if beam is not None else None,
+        tol,
+        None,
+        maxiter,
+        None,
+        new_axes={"vars": 4},
+        dtype=data.dtype,
+    )

--- a/tests/test_convolution.py
+++ b/tests/test_convolution.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
-from africanus.model.spi import fit_spi_components
 from numpy.testing._private.utils import assert_allclose
 
 from spimple.utils.convolution import Gaussian2D, convolve2gaussres
+from spimple.utils.fit_spi import fit_spi_components_np as fit_spi_components
 
 pmp = pytest.mark.parametrize
 

--- a/tests/test_fit_spi.py
+++ b/tests/test_fit_spi.py
@@ -1,0 +1,125 @@
+"""Per component weighting in the spectral index fit.
+
+The load bearing property is that fitting the apparent image with the beam in
+the model and fitting the intrinsic image with B ** 2 weights are the same
+least squares problem:
+
+    sum_v w_v (d_app - B_v M_v) ** 2 = sum_v (w_v B_v ** 2) (d_int - M_v) ** 2
+
+That identity is what makes spifit's intrinsic path a consistency check on the
+apparent path rather than a second, differently biased estimator.
+"""
+
+import numpy as np
+import pytest
+
+from spimple.utils.fit_spi import fit_spi_components_np
+
+pmp = pytest.mark.parametrize
+
+
+def _spectra(nband=8, ncomps=64, alpha=-0.7, seed=42, noise=0.0):
+    """Apparent and intrinsic spectra on a beam that narrows with frequency."""
+    rng = np.random.default_rng(seed)
+    freqs = np.linspace(0.9e9, 1.7e9, nband)
+    freq0 = freqs[nband // 2]
+
+    i0 = rng.uniform(0.5, 5.0, ncomps)
+    alphas = alpha + rng.normal(0.0, 0.1, ncomps)
+    intrinsic = i0[:, None] * (freqs[None, :] / freq0) ** alphas[:, None]
+
+    # a gaussian primary beam whose width scales as 1 / nu, sampled over a range
+    # of radii so the components span the usable part of the field
+    radius = np.linspace(0.0, 0.5, ncomps)
+    width = 0.45 * freqs[0] / freqs
+    beam = np.exp(-0.5 * (radius[:, None] / width[None, :]) ** 2)
+
+    apparent = beam * intrinsic
+    if noise:
+        apparent = apparent + rng.normal(0.0, noise, apparent.shape)
+    return freqs, freq0, beam, apparent, i0, alphas
+
+
+@pmp("noise", [0.0, 1e-3])
+def test_intrinsic_with_beam_squared_weights_matches_the_apparent_fit(noise):
+    """The two parameterisations are one least squares problem, to machine precision."""
+    freqs, freq0, beam, apparent, _, _ = _spectra(noise=noise)
+    w = np.linspace(1.0, 0.4, freqs.size)  # unequal band weights, as WSUM gives
+
+    app = fit_spi_components_np(apparent, w, freqs, freq0, beam=beam, tol=1e-10, maxiter=500)
+    intr = fit_spi_components_np(apparent / beam, w[None, :] * beam**2, freqs, freq0, tol=1e-10, maxiter=500)
+
+    np.testing.assert_allclose(intr[0], app[0], rtol=0, atol=1e-10)  # alpha
+    np.testing.assert_allclose(intr[2], app[2], rtol=0, atol=1e-10)  # I0
+    # the variances are chi squared rescaled, so noiseless they are pure
+    # roundoff; atol keeps that from being compared relatively
+    np.testing.assert_allclose(intr[1], app[1], rtol=1e-9, atol=1e-20)  # alpha variance
+    np.testing.assert_allclose(intr[3], app[3], rtol=1e-9, atol=1e-20)  # I0 variance
+
+
+def test_flat_weights_on_the_intrinsic_image_disagree_with_the_apparent_fit():
+    """Guards the equivalence above against a vacuous pass.
+
+    Unity weights are what spifit used before, and they give a measurably
+    different answer wherever the beam varies.
+    """
+    freqs, freq0, beam, apparent, _, _ = _spectra(noise=1e-3)
+    w = np.ones(freqs.size)
+
+    app = fit_spi_components_np(apparent, w, freqs, freq0, beam=beam, tol=1e-10, maxiter=500)
+    flat = fit_spi_components_np(apparent / beam, w, freqs, freq0, tol=1e-10, maxiter=500)
+
+    assert np.abs(flat[0] - app[0]).max() > 1e-3
+
+
+def test_beam_squared_weights_beat_flat_weights_on_noisy_edge_components():
+    """The point of the change: lower alpha scatter where the beam varies most."""
+    freqs, freq0, beam, apparent, _, alphas = _spectra(ncomps=400, noise=2e-3)
+    w = np.ones(freqs.size)
+
+    flat = fit_spi_components_np(apparent / beam, w, freqs, freq0, tol=1e-10, maxiter=500)
+    wgt = fit_spi_components_np(apparent / beam, w[None, :] * beam**2, freqs, freq0, tol=1e-10, maxiter=500)
+
+    edge = beam.min(axis=1) < 0.5
+    assert np.std(wgt[0][edge] - alphas[edge]) < np.std(flat[0][edge] - alphas[edge])
+
+
+def test_a_1d_weight_vector_is_broadcast_over_components():
+    """Back compatibility with the africanus signature."""
+    freqs, freq0, beam, apparent, _, _ = _spectra()
+    w = np.linspace(1.0, 0.4, freqs.size)
+
+    one_d = fit_spi_components_np(apparent, w, freqs, freq0, beam=beam, tol=1e-10, maxiter=500)
+    two_d = fit_spi_components_np(
+        apparent, np.broadcast_to(w, apparent.shape).copy(), freqs, freq0, beam=beam, tol=1e-10, maxiter=500
+    )
+
+    np.testing.assert_allclose(two_d, one_d, rtol=0, atol=0)
+
+
+def test_mismatched_weights_are_rejected():
+    freqs, freq0, beam, apparent, _, _ = _spectra()
+
+    with pytest.raises(ValueError, match="does not match data"):
+        fit_spi_components_np(apparent, np.ones((3, freqs.size)), freqs, freq0, beam=beam)
+
+
+def test_the_dask_wrapper_accepts_per_component_weights():
+    da = pytest.importorskip("dask.array")
+    freqs, freq0, beam, apparent, _, _ = _spectra(ncomps=64)
+    from spimple.utils.fit_spi import fit_spi_components
+
+    w = np.linspace(1.0, 0.4, freqs.size)[None, :] * beam**2
+    chunks = (16, freqs.size)
+
+    out = fit_spi_components(
+        da.from_array(apparent / beam, chunks=chunks),
+        da.from_array(w, chunks=chunks),
+        da.from_array(freqs, chunks=(freqs.size,)),
+        np.float64(freq0),
+        tol=1e-10,
+        maxiter=500,
+    ).compute()
+    expected = fit_spi_components_np(apparent / beam, w, freqs, freq0, tol=1e-10, maxiter=500)
+
+    np.testing.assert_allclose(out, expected, rtol=1e-12, atol=1e-12)

--- a/tests/test_spifit.py
+++ b/tests/test_spifit.py
@@ -33,6 +33,29 @@ def test_apparent_scale_recovers_the_same_index(pfb_tree, true_alpha, tmp_path):
     assert np.median(fitted) == pytest.approx(true_alpha, abs=0.05)
 
 
+def test_intrinsic_and_apparent_scales_give_the_same_alpha(pfb_tree, tmp_path):
+    """The two scales are one weighted least squares problem, not two estimators.
+
+    The intrinsic fit drops the beam from the model and carries it as a B ** 2
+    weight instead, which is algebraically the same normal equations as fitting
+    the apparent image with the beam in the model. Any disagreement therefore
+    means BIMAGE, IMAGE and BEAM disagree in the tree rather than that the
+    estimators differ. Only the shared pixels are compared, because each scale
+    thresholds on its own image and the apparent one is attenuated.
+    """
+    app = str(tmp_path / "spi_app")
+    intr = str(tmp_path / "spi_int")
+    spifit(pfb_tree, app, flux_scale="apparent", products="a")
+    spifit(pfb_tree, intr, flux_scale="intrinsic", products="a")
+
+    a = fits.getdata(f"{app}_time0.alpha.fits").squeeze()
+    i = fits.getdata(f"{intr}_time0.alpha.fits").squeeze()
+    both = np.isfinite(a) & np.isfinite(i)
+
+    assert both.sum() > 0
+    np.testing.assert_allclose(i[both], a[both], rtol=0, atol=1e-5)
+
+
 def test_unfitted_pixels_are_nan_not_zero(pfb_tree, tmp_path):
     out = str(tmp_path / "spi")
     spifit(pfb_tree, out, flux_scale="intrinsic", products="a")
@@ -179,5 +202,18 @@ def test_missing_product_error_names_what_is_available(pfb_tree, tmp_path):
         for var in ("BIMAGE", "IMAGE"):
             shutil.rmtree(f"{konly}/{node}/{var}", ignore_errors=True)
 
-    with pytest.raises(ValueError, match="KIMAGE"):
+    with pytest.raises(ValueError, match="KIMAGE") as excinfo:
         spifit(konly, str(tmp_path / "spi"), flux_scale="apparent", products="a")
+
+    # a KIMAGE-only tree has no fittable product at all, so the message has to
+    # send the user back to pfb restore rather than name another --flux-scale
+    assert "pfb restore" in str(excinfo.value)
+    assert "--outputs a" in str(excinfo.value)
+
+
+def test_mixed_flux_scale_is_rejected(pfb_tree, tmp_path):
+    """The mixed scale was removed; the error must say what to run instead."""
+    with pytest.raises(ValueError, match="mixed was removed") as excinfo:
+        spifit(pfb_tree, str(tmp_path / "spi"), flux_scale="mixed", products="a")
+
+    assert "pfb restore" in str(excinfo.value)


### PR DESCRIPTION
## Why

`spifit --flux-scale intrinsic` was fitting with unity weights, which is not the right
estimator. Image-plane noise is flat in the *apparent* image, so `IMAGE = BIMAGE / BEAM`
has variance `σ_ν² / B(ν,p)²` and its inverse-variance weight is `B(ν,p)² / σ_ν²`. The
beam narrows with frequency, so that weight is genuinely per (component, channel) and
does not factorise into a `(chan,)` vector — which is exactly what
`africanus.model.spi.fit_spi_components` accepts, and why the limitation existed.

## What changed

**`utils/fit_spi.py`** (vendored from africanus in the parent commit) now takes weights of
shape `(comps, chan)` as well as `(chan,)`:

- the inner loop indexes `wgt = weights[comp]` rather than a shared `weights[v]`
- 1-D input is broadcast and made contiguous — numba cannot index a zero-stride view row-wise
- mismatched shapes raise rather than broadcasting silently
- the dask wrapper picks `("comps","chan")` vs `("chan",)` from `weights.ndim`

**`core/spifit.py`** builds `w_ν · B(ν,p)²` over the fitted components for
`--flux-scale intrinsic`. `apparent` still passes the 1-D band weights with the beam in
the model.

### The two scales are now one problem written two ways

```
Σ_ν w_ν (d_app − B_ν M_ν)²  =  Σ_ν (w_ν B_ν²) (d_int − M_ν)²
```

so on a self-consistent tree (`BIMAGE == BEAM · IMAGE`) the intrinsic and apparent fits
agree to machine precision. That is what makes running both a useful check: they cannot
disagree because the estimators differ, only because the tree's stored products disagree.

### `--flux-scale mixed` removed

`KIMAGE` is an intrinsic model plus an *apparent* residual, so its signal and its noise sit
on different flux scales and no single beam relates them. The old path fitted it against
`B · M`, driving `I0` up roughly as `1/B` towards the field edge. Fitting it without a beam
mis-weights the residual instead — there is no correct setting, only two wrong ones.

Both the option and a KIMAGE-only tree now error out early naming the `pfb restore` rerun.
This matters because `pfb restore` defaults to `--outputs kK`, which writes `KIMAGE` *only*,
so the tree a user most likely has is exactly the one that cannot be fitted.

## Tests

- `tests/test_fit_spi.py` (new): pins the identity above at `atol=1e-10` clean and noisy,
  plus a guard test showing unity weights *do* diverge so the equivalence cannot pass
  vacuously; an efficiency test on edge components; 1-D back-compat; shape validation; and
  the dask wrapper against the numpy path.
- `tests/test_spifit.py`: end-to-end `test_intrinsic_and_apparent_scales_give_the_same_alpha`
  on `pfb_tree`, `test_mixed_flux_scale_is_rejected`, and the missing-product test extended
  to assert the restore hint.
- `tests/test_convolution.py` now imports the vendored kernel; nothing still imports
  `africanus.model.spi`.

198 passed, 1 skipped. Round-trip test passes against the regenerated cab.

## Docs

`docs/wiki/design-decisions.md` gains D17 and D18; the "mixed puts the beam in the model"
known-defect entry is deleted. One known defect is added and deliberately not fixed: for
genuinely mosaicked multi-pointing bands the correct weight is `SPATIALWGT = ΣB² + η`
rather than `BEAM² = (ΣB²/ΣB)²`, but moving to it means changing the apparent path too,
since both share the same flat-noise assumption. They coincide for single-pointing bands.

`README.md`'s pfb example used `--flux-scale mixed` as the recommended path; it now runs
`pfb restore --outputs iI` and fits `intrinsic`.

## Breaking changes

- `--flux-scale mixed` is rejected.
- `--flux-scale intrinsic` returns different alphas and errors wherever the beam varies
  across the band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
